### PR TITLE
🔀 feat/#12 → develop

### DIFF
--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -8,14 +8,46 @@
 
 /* Begin PBXBuildFile section */
 		34624F1029C1C11400518FB4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34624F0F29C1C11400518FB4 /* SnapKit */; };
+		34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F2F29CAE57D00518FB4 /* ShareViewController.swift */; };
+		34624F3329CAE57D00518FB4 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34624F3129CAE57D00518FB4 /* MainInterface.storyboard */; };
+		34624F3729CAE57D00518FB4 /* share.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 34624F2D29CAE57D00518FB4 /* share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		34624F3D29CAE61000518FB4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34624F3C29CAE61000518FB4 /* SnapKit */; };
 		346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */; };
 		346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8829B718B3004CEE9B /* ContentView.swift */; };
 		346FAD8B29B718B4004CEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8A29B718B4004CEE9B /* Assets.xcassets */; };
 		346FAD8E29B718B4004CEE9B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8D29B718B4004CEE9B /* Preview Assets.xcassets */; };
 /* End PBXBuildFile section */
 
+/* Begin PBXContainerItemProxy section */
+		34624F3529CAE57D00518FB4 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 346FAD7B29B718B3004CEE9B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 34624F2C29CAE57D00518FB4;
+			remoteInfo = share;
+		};
+/* End PBXContainerItemProxy section */
+
+/* Begin PBXCopyFilesBuildPhase section */
+		34624F3829CAE57D00518FB4 /* Embed Foundation Extensions */ = {
+			isa = PBXCopyFilesBuildPhase;
+			buildActionMask = 2147483647;
+			dstPath = "";
+			dstSubfolderSpec = 13;
+			files = (
+				34624F3729CAE57D00518FB4 /* share.appex in Embed Foundation Extensions */,
+			);
+			name = "Embed Foundation Extensions";
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXCopyFilesBuildPhase section */
+
 /* Begin PBXFileReference section */
 		34624F1129C1C12900518FB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		34624F2D29CAE57D00518FB4 /* share.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = share.appex; sourceTree = BUILT_PRODUCTS_DIR; };
+		34624F2F29CAE57D00518FB4 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
+		34624F3229CAE57D00518FB4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
+		34624F3429CAE57D00518FB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		346FAD8329B718B3004CEE9B /* InsightCapture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InsightCapture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightCaptureApp.swift; sourceTree = "<group>"; };
 		346FAD8829B718B3004CEE9B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -24,6 +56,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		34624F2A29CAE57D00518FB4 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34624F3D29CAE61000518FB4 /* SnapKit in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		346FAD8029B718B3004CEE9B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -42,10 +82,21 @@
 			name = Frameworks;
 			sourceTree = "<group>";
 		};
+		34624F2E29CAE57D00518FB4 /* share */ = {
+			isa = PBXGroup;
+			children = (
+				34624F2F29CAE57D00518FB4 /* ShareViewController.swift */,
+				34624F3129CAE57D00518FB4 /* MainInterface.storyboard */,
+				34624F3429CAE57D00518FB4 /* Info.plist */,
+			);
+			path = share;
+			sourceTree = "<group>";
+		};
 		346FAD7A29B718B3004CEE9B = {
 			isa = PBXGroup;
 			children = (
 				346FAD8529B718B3004CEE9B /* InsightCapture */,
+				34624F2E29CAE57D00518FB4 /* share */,
 				346FAD8429B718B3004CEE9B /* Products */,
 				34624F1229C1C12E00518FB4 /* Frameworks */,
 			);
@@ -55,6 +106,7 @@
 			isa = PBXGroup;
 			children = (
 				346FAD8329B718B3004CEE9B /* InsightCapture.app */,
+				34624F2D29CAE57D00518FB4 /* share.appex */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -82,6 +134,26 @@
 /* End PBXGroup section */
 
 /* Begin PBXNativeTarget section */
+		34624F2C29CAE57D00518FB4 /* share */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 34624F3B29CAE57D00518FB4 /* Build configuration list for PBXNativeTarget "share" */;
+			buildPhases = (
+				34624F2929CAE57D00518FB4 /* Sources */,
+				34624F2A29CAE57D00518FB4 /* Frameworks */,
+				34624F2B29CAE57D00518FB4 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = share;
+			packageProductDependencies = (
+				34624F3C29CAE61000518FB4 /* SnapKit */,
+			);
+			productName = share;
+			productReference = 34624F2D29CAE57D00518FB4 /* share.appex */;
+			productType = "com.apple.product-type.app-extension";
+		};
 		346FAD8229B718B3004CEE9B /* InsightCapture */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 346FAD9129B718B4004CEE9B /* Build configuration list for PBXNativeTarget "InsightCapture" */;
@@ -89,10 +161,12 @@
 				346FAD7F29B718B3004CEE9B /* Sources */,
 				346FAD8029B718B3004CEE9B /* Frameworks */,
 				346FAD8129B718B3004CEE9B /* Resources */,
+				34624F3829CAE57D00518FB4 /* Embed Foundation Extensions */,
 			);
 			buildRules = (
 			);
 			dependencies = (
+				34624F3629CAE57D00518FB4 /* PBXTargetDependency */,
 			);
 			name = InsightCapture;
 			packageProductDependencies = (
@@ -112,6 +186,9 @@
 				LastSwiftUpdateCheck = 1420;
 				LastUpgradeCheck = 1420;
 				TargetAttributes = {
+					34624F2C29CAE57D00518FB4 = {
+						CreatedOnToolsVersion = 14.2;
+					};
 					346FAD8229B718B3004CEE9B = {
 						CreatedOnToolsVersion = 14.2;
 					};
@@ -134,11 +211,20 @@
 			projectRoot = "";
 			targets = (
 				346FAD8229B718B3004CEE9B /* InsightCapture */,
+				34624F2C29CAE57D00518FB4 /* share */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		34624F2B29CAE57D00518FB4 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34624F3329CAE57D00518FB4 /* MainInterface.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		346FAD8129B718B3004CEE9B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -151,6 +237,14 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		34624F2929CAE57D00518FB4 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		346FAD7F29B718B3004CEE9B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -162,7 +256,76 @@
 		};
 /* End PBXSourcesBuildPhase section */
 
+/* Begin PBXTargetDependency section */
+		34624F3629CAE57D00518FB4 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 34624F2C29CAE57D00518FB4 /* share */;
+			targetProxy = 34624F3529CAE57D00518FB4 /* PBXContainerItemProxy */;
+		};
+/* End PBXTargetDependency section */
+
+/* Begin PBXVariantGroup section */
+		34624F3129CAE57D00518FB4 /* MainInterface.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				34624F3229CAE57D00518FB4 /* Base */,
+			);
+			name = MainInterface.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		34624F3929CAE57D00518FB4 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JPL38XBHJ4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = share/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = share;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.led.InsightCapture.share;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		34624F3A29CAE57D00518FB4 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				DEVELOPMENT_TEAM = JPL38XBHJ4;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = share/Info.plist;
+				INFOPLIST_KEY_CFBundleDisplayName = share;
+				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+					"@executable_path/../../Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.led.InsightCapture.share;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SKIP_INSTALL = YES;
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
 		346FAD8F29B718B4004CEE9B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -280,6 +443,7 @@
 		346FAD9229B718B4004CEE9B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -311,6 +475,7 @@
 		346FAD9329B718B4004CEE9B /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_STYLE = Automatic;
@@ -342,6 +507,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		34624F3B29CAE57D00518FB4 /* Build configuration list for PBXNativeTarget "share" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				34624F3929CAE57D00518FB4 /* Debug */,
+				34624F3A29CAE57D00518FB4 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		346FAD7E29B718B3004CEE9B /* Build configuration list for PBXProject "InsightCapture" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -375,6 +549,11 @@
 
 /* Begin XCSwiftPackageProductDependency section */
 		34624F0F29C1C11400518FB4 /* SnapKit */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 34624F0E29C1C11400518FB4 /* XCRemoteSwiftPackageReference "SnapKit" */;
+			productName = SnapKit;
+		};
+		34624F3C29CAE61000518FB4 /* SnapKit */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = 34624F0E29C1C11400518FB4 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;

--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		34624F3329CAE57D00518FB4 /* MainInterface.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 34624F3129CAE57D00518FB4 /* MainInterface.storyboard */; };
 		34624F3729CAE57D00518FB4 /* share.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 34624F2D29CAE57D00518FB4 /* share.appex */; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
 		34624F3D29CAE61000518FB4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34624F3C29CAE61000518FB4 /* SnapKit */; };
+		34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F3F29CB300A00518FB4 /* UIColor+.swift */; };
+		34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F3F29CB300A00518FB4 /* UIColor+.swift */; };
 		346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */; };
 		346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8829B718B3004CEE9B /* ContentView.swift */; };
 		346FAD8B29B718B4004CEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8A29B718B4004CEE9B /* Assets.xcassets */; };
@@ -48,6 +50,7 @@
 		34624F2F29CAE57D00518FB4 /* ShareViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ShareViewController.swift; sourceTree = "<group>"; };
 		34624F3229CAE57D00518FB4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		34624F3429CAE57D00518FB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		34624F3F29CB300A00518FB4 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
 		346FAD8329B718B3004CEE9B /* InsightCapture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InsightCapture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightCaptureApp.swift; sourceTree = "<group>"; };
 		346FAD8829B718B3004CEE9B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -92,6 +95,14 @@
 			path = share;
 			sourceTree = "<group>";
 		};
+		34624F3E29CB2FFB00518FB4 /* Extensions */ = {
+			isa = PBXGroup;
+			children = (
+				34624F3F29CB300A00518FB4 /* UIColor+.swift */,
+			);
+			path = Extensions;
+			sourceTree = "<group>";
+		};
 		346FAD7A29B718B3004CEE9B = {
 			isa = PBXGroup;
 			children = (
@@ -114,6 +125,7 @@
 		346FAD8529B718B3004CEE9B /* InsightCapture */ = {
 			isa = PBXGroup;
 			children = (
+				34624F3E29CB2FFB00518FB4 /* Extensions */,
 				34624F1129C1C12900518FB4 /* Info.plist */,
 				346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */,
 				346FAD8829B718B3004CEE9B /* ContentView.swift */,
@@ -242,6 +254,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */,
+				34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -251,6 +264,7 @@
 			files = (
 				346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */,
 				346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */,
+				34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/InsightCapture/InsightCapture/Extensions/UIColor+.swift
+++ b/InsightCapture/InsightCapture/Extensions/UIColor+.swift
@@ -1,0 +1,36 @@
+//
+//  UIColor+.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/22.
+//
+
+import UIKit
+
+extension UIColor {
+    public convenience init?(hex: String) {
+        let r, g, b, a: CGFloat
+
+        if hex.hasPrefix("#") {
+            let start = hex.index(hex.startIndex, offsetBy: 1)
+            let hexColor = String(hex[start...])
+
+            if hexColor.count == 8 {
+                let scanner = Scanner(string: hexColor)
+                var hexNumber: UInt64 = 0
+
+                if scanner.scanHexInt64(&hexNumber) {
+                    r = CGFloat((hexNumber & 0xff000000) >> 24) / 255
+                    g = CGFloat((hexNumber & 0x00ff0000) >> 16) / 255
+                    b = CGFloat((hexNumber & 0x0000ff00) >> 8) / 255
+                    a = CGFloat(hexNumber & 0x000000ff) / 255
+
+                    self.init(red: r, green: g, blue: b, alpha: a)
+                    return
+                }
+            }
+        }
+
+        return nil
+    }
+}

--- a/InsightCapture/share/Base.lproj/MainInterface.storyboard
+++ b/InsightCapture/share/Base.lproj/MainInterface.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="j1y-V4-xli">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--Share View Controller-->
+        <scene sceneID="ceB-am-kn3">
+            <objects>
+                <viewController id="j1y-V4-xli" customClass="ShareViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" opaque="NO" contentMode="scaleToFill" id="wbc-yd-nQP">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" red="0.0" green="0.0" blue="0.0" alpha="0.0" colorSpace="custom" customColorSpace="sRGB"/>
+                        <viewLayoutGuide key="safeArea" id="1Xd-am-t49"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="CEy-Cv-SGf" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/InsightCapture/share/Info.plist
+++ b/InsightCapture/share/Info.plist
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>NSExtensionActivationRule</key>
+			<string>TRUEPREDICATE</string>
+		</dict>
+		<key>NSExtensionMainStoryboard</key>
+		<string>MainInterface</string>
+		<key>NSExtensionPointIdentifier</key>
+		<string>com.apple.share-services</string>
+	</dict>
+</dict>
+</plist>

--- a/InsightCapture/share/ShareViewController.swift
+++ b/InsightCapture/share/ShareViewController.swift
@@ -1,0 +1,214 @@
+import UIKit
+import Social
+import MobileCoreServices
+import UniformTypeIdentifiers
+
+import SnapKit
+
+class ShareViewController: UIViewController {
+    
+    var isShowingSource: Bool = true
+    var thumbnailImage: UIImage?
+    
+    // MARK: UI Components
+    
+    lazy var backgroundView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray6
+        view.layer.cornerRadius = 15
+        view.clipsToBounds =  true
+        return view
+    }()
+    
+    lazy var navigationBar: UINavigationBar = {
+        let bar = UINavigationBar()
+        bar.barStyle = .default
+        
+        let item = UINavigationItem(title: "HELLOWORLD")
+        item.leftBarButtonItem = UIBarButtonItem(title: "취소", style: .plain, target: self, action: nil)
+        item.rightBarButtonItem = UIBarButtonItem(title: "저장", style: .done, target: self, action: nil)
+        
+        bar.items = [item]
+        
+        return bar
+    }()
+    
+    lazy var contentView: UIView = {
+        let view = UIView()
+        return view
+    } ()
+    
+    lazy var sourceView: UIView = {
+        let view = UIView()
+        view.clipsToBounds = true
+        return view
+    }()
+    
+    lazy var sourceImageView: UIImageView = {
+        let view = UIImageView()
+        view.contentMode = .scaleAspectFill
+        return view
+    }()
+    
+    lazy var textFieldView: UIView = {
+        let view = UIView()
+        return view
+    }()
+    
+    lazy var titleTextField: UITextField = {
+        let textField = UITextField()
+        textField.placeholder = "제목"
+        textField.backgroundColor = .clear
+        textField.font = .systemFont(ofSize: 16, weight: .semibold)
+        return textField
+    }()
+    
+    lazy var divider: UIView = {
+        let view = UIView()
+        view.backgroundColor = .systemGray4
+        return view
+    }()
+    
+    let textViewPlaceHolder: String = "내용"
+    lazy var descriptionTextField: UITextView = {
+        let textField = UITextView()
+        textField.text = textViewPlaceHolder
+        textField.textColor = .systemGray2
+        textField.backgroundColor = .clear
+        textField.font = .systemFont(ofSize: 16, weight: .medium)
+        textField.textContainerInset = .zero
+        textField.textContainer.lineFragmentPadding = 0
+        textField.delegate = self
+        return textField
+    }()
+    
+    override func viewDidLoad() {
+        setLayout()
+        
+        // MARK: Data 가져오기
+        
+        let extensionItems = extensionContext?.inputItems as! [NSExtensionItem]
+        
+        // 가져온 데이터 중에서
+        for items in extensionItems {
+            // NSItemProvider 배열에 담긴 여러 미디어 데이터 중에서
+            if let itemProviders = items.attachments {
+                // 미디어 데이터를 하나 확인해서
+                for itemProvider in itemProviders {
+                    
+                    // 만약 이미지 파일이라면
+                    if itemProvider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
+                        itemProvider.loadItem(forTypeIdentifier: UTType.image.identifier, options: nil) { (data, error) in
+                            
+                            if let data = data {
+                                let image = UIImage(data: NSData(contentsOf: (data as! NSURL) as URL)! as Data)
+                                
+                                DispatchQueue.main.async {
+                                    self.sourceImageView.image = image
+                                }
+                            }
+                        }
+                    }
+                    
+                    // 만약 URL 타입이라면
+                    if itemProvider.hasItemConformingToTypeIdentifier(kUTTypeURL as String) {
+                        
+                    }
+                }
+            }
+        }
+    }
+    
+    
+}
+
+extension ShareViewController {
+    func setLayout() {
+        self.view.addSubview(backgroundView)
+        backgroundView.snp.makeConstraints {
+            $0.width.height.centerX.equalToSuperview()
+            $0.centerY.equalToSuperview().offset(30)
+        }
+        
+        self.backgroundView.addSubview(navigationBar)
+        navigationBar.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalToSuperview()
+        }
+        
+        self.backgroundView.addSubview(contentView)
+        contentView.snp.makeConstraints {
+            $0.horizontalEdges.bottom.equalToSuperview()
+            $0.top.equalTo(navigationBar.snp.bottom)
+        }
+        
+        self.contentView.addSubview(sourceView)
+        setImageSourceLayout()
+        
+        self.contentView.addSubview(textFieldView)
+        setTextFieldLayout()
+    }
+    
+    func setImageSourceLayout() {
+        sourceView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.height.equalTo(124)
+        }
+        
+        self.sourceView.addSubview(sourceImageView)
+        sourceImageView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
+    func setTextFieldLayout() {
+        textFieldView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview().inset(16)
+            $0.top.equalTo(sourceView.snp.bottom)
+            $0.bottom.equalToSuperview()
+        }
+        
+        self.textFieldView.addSubview(titleTextField)
+        titleTextField.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalTo(textFieldView.snp.top).offset(4)
+            $0.height.equalTo(30)
+        }
+        
+        self.textFieldView.addSubview(divider)
+        divider.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalTo(titleTextField.snp.bottom).offset(8)
+            $0.height.equalTo(1)
+        }
+        
+        self.textFieldView.addSubview(descriptionTextField)
+        descriptionTextField.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalTo(divider.snp.bottom).offset(8)
+            $0.bottom.equalToSuperview()
+        }
+        
+    }
+}
+
+extension ShareViewController {
+    
+}
+
+extension ShareViewController: UITextViewDelegate {
+    func textViewDidBeginEditing(_ textView: UITextView) {
+        if textView.text == textViewPlaceHolder {
+            textView.text = nil
+            textView.textColor = .black
+        }
+    }
+    
+    func textViewDidEndEditing(_ textView: UITextView) {
+        if textView.text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            textView.text = textViewPlaceHolder
+            textView.textColor = .systemGray3
+        }
+    }
+}


### PR DESCRIPTION
# 작업 내용 설명
- Share Extension을 통해 외부 공유하기 탭에서 사용하는 기능 구현
- LinkPresentation을 통해 링크에서 메타데이터를 가져오는 기능 구현

# 관련 이슈
- #12 

# 작업의 결과물
## Share Extension
프로젝트에서 new target으로 share extension을 추가해주면 ShareViewController.swift 파일에 아래 코드가 작성된다.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/39216546/227101177-f2571b1c-2f20-4efd-a586-ad9f813fc2a7.png">
```swift
class ShareViewController: SLComposeServiceViewController {

    override func isContentValid() -> Bool {
        // Post 버튼을 활성화하는 조건을 설정
        
        return true
    }

    override func didSelectPost() {
        // Post 버튼을 선택한 경우 실행되는 함수
    
        // 아래 함수가 실행되면 ShareView가 닫힘
        self.extensionContext!.completeRequest(returningItems: [], completionHandler: nil)
    }

    override func didSelectCancel() {
        // Cancel 버튼을 선택한 경우 실행되는 함수
        
    }
    
    override func configurationItems() -> [Any]! {
        // ShareView에서 설정할 수 있는 여러 옵션을 설정
        
        return []
    }
}
```
위 뷰가 SLComposeServiceViewController를 상속하기 때문에, 기본적인 뷰를 아래 화면처럼 알아서 그려준다.
<img width="350" alt="image" src="https://user-images.githubusercontent.com/39216546/227102555-78c79f3a-2282-47e3-a5b2-7612284675d5.png">

만약에 Custom View를 사용하고 싶을 때에는 StoryBoard에서 ViewController를 연결해주기만 하면 된다. 꼭 SLComposeServiceViewController를 상속하지 않아도 되며, ViewController을 상속하기만 하면 된다. 
<img width="500" alt="image" src="https://user-images.githubusercontent.com/39216546/227102910-f0d85408-90d1-4170-b662-b901db162d28.png">

공유하기 기능을 통해 들어오는 데이터는 `ViewDidLoad()` 함수에서 `extensionContext`을 통해 캐치해 사용할 수 있다.

`ViewDidLoad()` 함수에서 아래 코드를 통해 `extensionContext`에서 데이터를 가져와 데이터 타입을 구분하고, 이에 대한 처리를 한 뒤 데이터를 사용할 수 있다. 
```swift
override func viewDidLoad() {
    let extensionItems = extensionContext?.inputItems as! [NSExtensionItem]
            isShowingSourceViewIndicator = true

            // 가져온 데이터 중에서
            for items in extensionItems {
                // NSItemProvider 배열에 담긴 여러 미디어 데이터 중에서
                if let itemProviders = items.attachments {
                    // 미디어 데이터를 하나 확인해서
                    for itemProvider in itemProviders {
                        
                        // 만약 이미지 파일이라면
                        if itemProvider.hasItemConformingToTypeIdentifier(UTType.image.identifier) {
                            itemProvider.loadItem(forTypeIdentifier: UTType.image.identifier, options: nil) { (data, error) in
                                if let data = data {
                                    let image = UIImage(data: NSData(contentsOf: (data as! NSURL) as URL)! as Data)
                                    // image에 대한 처리
                                }
                            }
                        }

                        // 만약 URL 타입이라면
                        if itemProvider.hasItemConformingToTypeIdentifier(UTType.url.identifier) {
                            itemProvider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { (url, error) in
                                // url에 대한 처리
                            }
                        }

                        // 다른 데이터 타입도 여기에서 체크하여 사용할 수 있음.
                    }
                }
            }
        }
    }
}
```

### 작성한 UI
|URL을 공유한 경우|이미지를 공유한 경우|
|---|---|
|<img width="489" alt="image" src="https://user-images.githubusercontent.com/39216546/227118072-107fb543-fdda-478f-9966-78f0e262a595.png">|<img width="489" alt="image" src="https://user-images.githubusercontent.com/39216546/227118171-98f525cb-3610-4ee3-a5aa-99301108c9f0.png">|

## Link Presentation
Link Presentation 프레임워크를 사용하면, URL 주소를 받아와 아래와 같은 미리보기를 보여줄 수 있다.
<img width="400" alt="image" src="https://user-images.githubusercontent.com/39216546/227182442-fe812528-7780-412d-b461-afa2f6324e75.png">

위와 같이 프레임워크의 LPLinkView를 사용하면 URL에서 썸네일, 타이틀, 링크를 포함하는 깔끔한 UI와 탭하면 앱페이지로 이동하는 뷰를 제공하고 있다.

만약에, 원하는 형태로 뷰를 만든다거나 필요한 메타데이터만 뽑아와 사용하고 싶다면, Link Presentation 프레임워크에서 아래와 같은 코드를 작성하여 호출하고 사용할 수 있다.
```swift
func fetchData(from url: URL) {
    let provider = LPMetadataProvider()
    provider.startFetchingMetadata(for: url) { metaData, error in
        if let error = error { return }
        guard let data = metaData else { return }
    }
}
```

위와 같은 방식으로 생성한 LPLinkMetadata 타입의 데이터에는 다양한 메타데이터 값들을 가지고 있다.
<img width="500" alt="image" src="https://user-images.githubusercontent.com/39216546/227184400-b4457108-a494-4162-baec-208defd68758.png">

LPLinkMetadata 타입에 대한 [애플 공식 개발자 문서](https://developer.apple.com/documentation/linkpresentation/lplinkmetadata)에서는 단순히 title, url, 이미지나 아이콘에 대한 데이터만 가져오도록 해주고 있다. 그러나 위에서 본 것 처럼, 메타데이터로 가져오는 값들이 굉장히 다양한데, 이러한 값들을 사용하기 위해서는 `data.value(forkey: "프로퍼티명")`을 통해 이러한 값들을 가져올 수 있다.

```swift
self.urlDescription = data.value(forKey: "summary") as! String
```

### 작성한 UI
<img width="400" alt="image" src="https://user-images.githubusercontent.com/39216546/227190119-09828fe2-0845-4323-80a5-6d84d80e1572.png">


Close #12 