### PR TITLE
✨[#4] Core Data 기능 구현

### DIFF
--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -18,6 +18,8 @@
 		34624F4629CCA10D00518FB4 /* InsightDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4329CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld */; };
 		34624F4929CCA13D00518FB4 /* InsightData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */; };
 		34624F4A29CCA13D00518FB4 /* InsightData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */; };
+		34624F4C29CCA22C00518FB4 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */; };
+		34624F4D29CCA22C00518FB4 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */; };
 		346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */; };
 		346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8829B718B3004CEE9B /* ContentView.swift */; };
 		346FAD8B29B718B4004CEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8A29B718B4004CEE9B /* Assets.xcassets */; };
@@ -58,6 +60,8 @@
 		34624F4429CC9FDA00518FB4 /* InsightDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = InsightDataModel.xcdatamodel; sourceTree = "<group>"; };
 		34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightData+CoreDataClass.swift"; sourceTree = "<group>"; };
 		34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightData+CoreDataProperties.swift"; sourceTree = "<group>"; };
+		34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
+		34624F4E29CCA24800518FB4 /* InsightCapture.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = InsightCapture.entitlements; sourceTree = "<group>"; };
 		346FAD8329B718B3004CEE9B /* InsightCapture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InsightCapture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightCaptureApp.swift; sourceTree = "<group>"; };
 		346FAD8829B718B3004CEE9B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -116,6 +120,7 @@
 				34624F4329CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld */,
 				34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */,
 				34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */,
+				34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -142,6 +147,7 @@
 		346FAD8529B718B3004CEE9B /* InsightCapture */ = {
 			isa = PBXGroup;
 			children = (
+				34624F4E29CCA24800518FB4 /* InsightCapture.entitlements */,
 				34624F4229CC9EB500518FB4 /* CoreData */,
 				34624F3E29CB2FFB00518FB4 /* Extensions */,
 				34624F1129C1C12900518FB4 /* Info.plist */,
@@ -273,6 +279,7 @@
 			files = (
 				34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */,
 				34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */,
+				34624F4D29CCA22C00518FB4 /* CoreDataManager.swift in Sources */,
 				34624F4629CCA10D00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -286,6 +293,7 @@
 				346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */,
 				346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */,
 				34624F4529CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
+				34624F4C29CCA22C00518FB4 /* CoreDataManager.swift in Sources */,
 				34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -482,6 +490,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = InsightCapture/InsightCapture.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"InsightCapture/Preview Content\"";
@@ -514,6 +523,7 @@
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_ENTITLEMENTS = InsightCapture/InsightCapture.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"InsightCapture/Preview Content\"";

--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -14,6 +14,10 @@
 		34624F3D29CAE61000518FB4 /* SnapKit in Frameworks */ = {isa = PBXBuildFile; productRef = 34624F3C29CAE61000518FB4 /* SnapKit */; };
 		34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F3F29CB300A00518FB4 /* UIColor+.swift */; };
 		34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F3F29CB300A00518FB4 /* UIColor+.swift */; };
+		34624F4529CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4329CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld */; };
+		34624F4629CCA10D00518FB4 /* InsightDataModel.xcdatamodeld in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4329CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld */; };
+		34624F4929CCA13D00518FB4 /* InsightData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */; };
+		34624F4A29CCA13D00518FB4 /* InsightData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */; };
 		346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */; };
 		346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8829B718B3004CEE9B /* ContentView.swift */; };
 		346FAD8B29B718B4004CEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8A29B718B4004CEE9B /* Assets.xcassets */; };
@@ -51,6 +55,9 @@
 		34624F3229CAE57D00518FB4 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/MainInterface.storyboard; sourceTree = "<group>"; };
 		34624F3429CAE57D00518FB4 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		34624F3F29CB300A00518FB4 /* UIColor+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+.swift"; sourceTree = "<group>"; };
+		34624F4429CC9FDA00518FB4 /* InsightDataModel.xcdatamodel */ = {isa = PBXFileReference; lastKnownFileType = wrapper.xcdatamodel; path = InsightDataModel.xcdatamodel; sourceTree = "<group>"; };
+		34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightData+CoreDataClass.swift"; sourceTree = "<group>"; };
+		34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightData+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		346FAD8329B718B3004CEE9B /* InsightCapture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InsightCapture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightCaptureApp.swift; sourceTree = "<group>"; };
 		346FAD8829B718B3004CEE9B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -103,6 +110,16 @@
 			path = Extensions;
 			sourceTree = "<group>";
 		};
+		34624F4229CC9EB500518FB4 /* CoreData */ = {
+			isa = PBXGroup;
+			children = (
+				34624F4329CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld */,
+				34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */,
+				34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */,
+			);
+			path = CoreData;
+			sourceTree = "<group>";
+		};
 		346FAD7A29B718B3004CEE9B = {
 			isa = PBXGroup;
 			children = (
@@ -125,6 +142,7 @@
 		346FAD8529B718B3004CEE9B /* InsightCapture */ = {
 			isa = PBXGroup;
 			children = (
+				34624F4229CC9EB500518FB4 /* CoreData */,
 				34624F3E29CB2FFB00518FB4 /* Extensions */,
 				34624F1129C1C12900518FB4 /* Info.plist */,
 				346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */,
@@ -255,6 +273,7 @@
 			files = (
 				34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */,
 				34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */,
+				34624F4629CCA10D00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -262,8 +281,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34624F4A29CCA13D00518FB4 /* InsightData+CoreDataProperties.swift in Sources */,
+				34624F4929CCA13D00518FB4 /* InsightData+CoreDataClass.swift in Sources */,
 				346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */,
 				346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */,
+				34624F4529CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 				34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -573,6 +595,19 @@
 			productName = SnapKit;
 		};
 /* End XCSwiftPackageProductDependency section */
+
+/* Begin XCVersionGroup section */
+		34624F4329CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld */ = {
+			isa = XCVersionGroup;
+			children = (
+				34624F4429CC9FDA00518FB4 /* InsightDataModel.xcdatamodel */,
+			);
+			currentVersion = 34624F4429CC9FDA00518FB4 /* InsightDataModel.xcdatamodel */;
+			path = InsightDataModel.xcdatamodeld;
+			sourceTree = "<group>";
+			versionGroupType = wrapper.xcdatamodel;
+		};
+/* End XCVersionGroup section */
 	};
 	rootObject = 346FAD7B29B718B3004CEE9B /* Project object */;
 }

--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -20,6 +20,10 @@
 		34624F4A29CCA13D00518FB4 /* InsightData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */; };
 		34624F4C29CCA22C00518FB4 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */; };
 		34624F4D29CCA22C00518FB4 /* CoreDataManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */; };
+		34624F5029CCA3F000518FB4 /* InsightData+CoreDataClass.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */; };
+		34624F5129CCA3F400518FB4 /* InsightData+CoreDataProperties.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */; };
+		34624F5329CEDD9E00518FB4 /* Insight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F5229CEDD9E00518FB4 /* Insight.swift */; };
+		34624F5429CEDF7600518FB4 /* Insight.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34624F5229CEDD9E00518FB4 /* Insight.swift */; };
 		346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */; };
 		346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8829B718B3004CEE9B /* ContentView.swift */; };
 		346FAD8B29B718B4004CEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8A29B718B4004CEE9B /* Assets.xcassets */; };
@@ -62,6 +66,8 @@
 		34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "InsightData+CoreDataProperties.swift"; sourceTree = "<group>"; };
 		34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CoreDataManager.swift; sourceTree = "<group>"; };
 		34624F4E29CCA24800518FB4 /* InsightCapture.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = InsightCapture.entitlements; sourceTree = "<group>"; };
+		34624F4F29CCA29500518FB4 /* share.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = share.entitlements; sourceTree = "<group>"; };
+		34624F5229CEDD9E00518FB4 /* Insight.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Insight.swift; sourceTree = "<group>"; };
 		346FAD8329B718B3004CEE9B /* InsightCapture.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = InsightCapture.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		346FAD8629B718B3004CEE9B /* InsightCaptureApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightCaptureApp.swift; sourceTree = "<group>"; };
 		346FAD8829B718B3004CEE9B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
@@ -99,6 +105,7 @@
 		34624F2E29CAE57D00518FB4 /* share */ = {
 			isa = PBXGroup;
 			children = (
+				34624F4F29CCA29500518FB4 /* share.entitlements */,
 				34624F2F29CAE57D00518FB4 /* ShareViewController.swift */,
 				34624F3129CAE57D00518FB4 /* MainInterface.storyboard */,
 				34624F3429CAE57D00518FB4 /* Info.plist */,
@@ -121,6 +128,7 @@
 				34624F4729CCA13D00518FB4 /* InsightData+CoreDataClass.swift */,
 				34624F4829CCA13D00518FB4 /* InsightData+CoreDataProperties.swift */,
 				34624F4B29CCA22C00518FB4 /* CoreDataManager.swift */,
+				34624F5229CEDD9E00518FB4 /* Insight.swift */,
 			);
 			path = CoreData;
 			sourceTree = "<group>";
@@ -277,8 +285,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				34624F5129CCA3F400518FB4 /* InsightData+CoreDataProperties.swift in Sources */,
+				34624F5029CCA3F000518FB4 /* InsightData+CoreDataClass.swift in Sources */,
 				34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */,
 				34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */,
+				34624F5429CEDF7600518FB4 /* Insight.swift in Sources */,
 				34624F4D29CCA22C00518FB4 /* CoreDataManager.swift in Sources */,
 				34624F4629CCA10D00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 			);
@@ -294,6 +305,7 @@
 				346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */,
 				34624F4529CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 				34624F4C29CCA22C00518FB4 /* CoreDataManager.swift in Sources */,
+				34624F5329CEDD9E00518FB4 /* Insight.swift in Sources */,
 				34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -323,6 +335,7 @@
 		34624F3929CAE57D00518FB4 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = share/share.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JPL38XBHJ4;
@@ -348,6 +361,7 @@
 		34624F3A29CAE57D00518FB4 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				CODE_SIGN_ENTITLEMENTS = share/share.entitlements;
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_TEAM = JPL38XBHJ4;

--- a/InsightCapture/InsightCapture/CoreData/CoreDataManager.swift
+++ b/InsightCapture/InsightCapture/CoreData/CoreDataManager.swift
@@ -1,0 +1,109 @@
+//
+//  CoreDataManager.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/24.
+//
+
+import Foundation
+import CoreData
+
+final class CoreDataManager {
+    static let shared = CoreDataManager()
+    
+    private let container = NSPersistentContainer(name: "InsightDataModel")
+    private var context: NSManagedObjectContext {
+        container.viewContext
+    }
+    
+    private var oldStoreURL: URL {
+        guard let directory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask)
+            .first
+        else {
+            return URL(fileURLWithPath: "")
+        }
+        return directory.appendingPathComponent(CoreData.databaseName)
+    }
+    
+    private var sharedStoreURL: URL {
+        guard let container = FileManager.default.containerURL(
+            forSecurityApplicationGroupIdentifier: CoreData.identifier)
+        else {
+            return URL(fileURLWithPath: "")
+        }
+        return container.appendingPathComponent(CoreData.databaseName)
+    }
+    
+    private init() {
+        loadStores()
+        migrateStore()
+        context.automaticallyMergesChangesFromParent = true
+    }
+}
+
+private extension CoreDataManager {
+    func loadStores() {
+        container.loadPersistentStores { desc, error in
+            if let error = error {
+                print(error.localizedDescription)
+            }
+        }
+    }
+    
+    func migrateStore() {
+        let coordinator = container.persistentStoreCoordinator
+        guard let oldStore = coordinator.persistentStore(for: oldStoreURL) else { return }
+        do {
+            let _ = try coordinator.migratePersistentStore(oldStore, to: sharedStoreURL, type: .sqlite)
+        } catch {
+            print(error.localizedDescription)
+        }
+        do {
+            try FileManager.default.removeItem(at: oldStoreURL)
+        } catch {
+            print(error.localizedDescription)
+        }
+    }
+}
+
+// MARK: CRUD
+
+extension CoreDataManager {
+    func save() {
+        do {
+            try context.save()
+        } catch {
+            print("FAIL TO SAVE CONTEXT")
+        }
+    }
+    
+    func getAllInsights() -> [InsightData] {
+        let fetchRequest: NSFetchRequest<InsightData> = InsightData.fetchRequest()
+        let result = try? context.fetch(fetchRequest)
+        
+        return result ?? []
+    }
+    
+    func createInsight(insight: Insight) {
+        let newInsight = InsightData(context: context)
+        
+        newInsight.thumbnailImage = insight.thumbnailImage?.pngData()
+        newInsight.createDate = insight.createDate
+        newInsight.url = insight.url
+        newInsight.insightString = insight.insightString
+        
+        save()
+    }
+    
+    func deleteInsight(insightData: InsightData) {
+        context.delete(insightData)
+        save()
+    }
+}
+
+enum CoreData {
+    static let identifier = "group.com.led.InsightCapture"
+    static let databaseName = "InsightDataModel.sqlite"
+}

--- a/InsightCapture/InsightCapture/CoreData/CoreDataManager.swift
+++ b/InsightCapture/InsightCapture/CoreData/CoreDataManager.swift
@@ -89,10 +89,15 @@ extension CoreDataManager {
     func createInsight(insight: Insight) {
         let newInsight = InsightData(context: context)
         
-        newInsight.thumbnailImage = insight.thumbnailImage?.pngData()
-        newInsight.createDate = insight.createDate
-        newInsight.url = insight.url
-        newInsight.insightString = insight.insightString
+        newInsight.type = insight.type
+        newInsight.createdDate = insight.createdDate
+        
+        newInsight.title = insight.title
+        newInsight.text = insight.text
+        
+        newInsight.urlString = insight.urlString
+        newInsight.quote = insight.quote
+        newInsight.image = insight.image
         
         save()
     }

--- a/InsightCapture/InsightCapture/CoreData/Insight.swift
+++ b/InsightCapture/InsightCapture/CoreData/Insight.swift
@@ -1,0 +1,54 @@
+//
+//  Insight.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/25.
+//
+
+import UIKit
+import Foundation
+
+class Insight {
+    public var type: Int16
+    public var text: String?
+    public var createdDate: Date?
+    public var title: String?
+    public var urlString: String?
+    public var image: Data?
+    public var quote: String?
+    
+    init(url: URL, text: String, title: String) {
+        self.type = InsightType.url.rawValue
+        self.text = text
+        self.createdDate = Date()
+        self.title = title
+        self.urlString = url.absoluteString
+    }
+    
+    init(image: UIImage, text: String, title: String) {
+        self.type = InsightType.image.rawValue
+        self.createdDate = Date()
+        self.title = title == "" ? "NO_title" : title
+        self.text = text == "" ? "NO_Content" : text
+        self.image = image.pngData()
+    }
+    
+    init(quote: String, text: String, title: String) {
+        self.type = InsightType.image.rawValue
+        self.createdDate = Date()
+        self.title = title == "" ? "NO_title" : title
+        self.text = text == "" ? "NO_Content" : text
+        self.quote = quote
+    }
+    
+    init(text: String, title: String) {
+        self.type = InsightType.brain.rawValue
+        self.createdDate = Date()
+        self.title = title == "" ? "NO_title" : title
+        self.text = text == "" ? "NO_Content" : text
+    }
+}
+
+enum InsightType: Int16 {
+    case image, url, quote, brain
+}

--- a/InsightCapture/InsightCapture/CoreData/InsightData+CoreDataClass.swift
+++ b/InsightCapture/InsightCapture/CoreData/InsightData+CoreDataClass.swift
@@ -1,0 +1,15 @@
+//
+//  InsightData+CoreDataClass.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/24.
+//
+//
+
+import Foundation
+import CoreData
+
+@objc(InsightData)
+public class InsightData: NSManagedObject {
+
+}

--- a/InsightCapture/InsightCapture/CoreData/InsightData+CoreDataProperties.swift
+++ b/InsightCapture/InsightCapture/CoreData/InsightData+CoreDataProperties.swift
@@ -20,7 +20,7 @@ extension InsightData {
     @NSManaged public var text: String?
     @NSManaged public var createdDate: Date?
     @NSManaged public var title: String?
-    @NSManaged public var url: String?
+    @NSManaged public var urlString: String?
     @NSManaged public var image: Data?
     @NSManaged public var quote: String?
 

--- a/InsightCapture/InsightCapture/CoreData/InsightData+CoreDataProperties.swift
+++ b/InsightCapture/InsightCapture/CoreData/InsightData+CoreDataProperties.swift
@@ -1,0 +1,31 @@
+//
+//  InsightData+CoreDataProperties.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/24.
+//
+//
+
+import Foundation
+import CoreData
+
+
+extension InsightData {
+
+    @nonobjc public class func fetchRequest() -> NSFetchRequest<InsightData> {
+        return NSFetchRequest<InsightData>(entityName: "InsightData")
+    }
+
+    @NSManaged public var type: Int16
+    @NSManaged public var text: String?
+    @NSManaged public var createdDate: Date?
+    @NSManaged public var title: String?
+    @NSManaged public var url: String?
+    @NSManaged public var image: Data?
+    @NSManaged public var quote: String?
+
+}
+
+extension InsightData : Identifiable {
+
+}

--- a/InsightCapture/InsightCapture/CoreData/InsightDataModel.xcdatamodeld/InsightDataModel.xcdatamodel/contents
+++ b/InsightCapture/InsightCapture/CoreData/InsightDataModel.xcdatamodeld/InsightDataModel.xcdatamodel/contents
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+    <entity name="InsightData" representedClassName="InsightData" syncable="YES" codeGenerationType="category">
+        <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
+        <attribute name="image" optional="YES" attributeType="Binary"/>
+        <attribute name="quote" optional="YES" attributeType="String"/>
+        <attribute name="text" optional="YES" attributeType="String"/>
+        <attribute name="title" optional="YES" attributeType="String"/>
+        <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="url" optional="YES" attributeType="String"/>
+    </entity>
+</model>

--- a/InsightCapture/InsightCapture/CoreData/InsightDataModel.xcdatamodeld/InsightDataModel.xcdatamodel/contents
+++ b/InsightCapture/InsightCapture/CoreData/InsightDataModel.xcdatamodeld/InsightDataModel.xcdatamodel/contents
@@ -1,12 +1,12 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
-    <entity name="InsightData" representedClassName="InsightData" syncable="YES" codeGenerationType="category">
+    <entity name="InsightData" representedClassName="InsightData" syncable="YES">
         <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="image" optional="YES" attributeType="Binary"/>
         <attribute name="quote" optional="YES" attributeType="String"/>
         <attribute name="text" optional="YES" attributeType="String"/>
         <attribute name="title" optional="YES" attributeType="String"/>
         <attribute name="type" optional="YES" attributeType="Integer 16" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="url" optional="YES" attributeType="String"/>
+        <attribute name="urlString" optional="YES" attributeType="String"/>
     </entity>
 </model>

--- a/InsightCapture/InsightCapture/InsightCapture.entitlements
+++ b/InsightCapture/InsightCapture/InsightCapture.entitlements
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict/>
+</plist>

--- a/InsightCapture/InsightCapture/InsightCapture.entitlements
+++ b/InsightCapture/InsightCapture/InsightCapture.entitlements
@@ -1,5 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
-<dict/>
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array>
+		<string>group.com.led.InsightCapture</string>
+	</array>
+</dict>
 </plist>

--- a/InsightCapture/share/share.entitlements
+++ b/InsightCapture/share/share.entitlements
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.application-groups</key>
+	<array/>
+</dict>
+</plist>

--- a/InsightCapture/share/share.entitlements
+++ b/InsightCapture/share/share.entitlements
@@ -3,6 +3,8 @@
 <plist version="1.0">
 <dict>
 	<key>com.apple.security.application-groups</key>
-	<array/>
+	<array>
+		<string>group.com.led.InsightCapture</string>
+	</array>
 </dict>
 </plist>


### PR DESCRIPTION
# 작업 내용 설명
코어데이터 모델과 CoreDataManager.swift 파일을 추가하여, Share Extension과 메인 앱 간에 코어데이터를 연동함.

# 관련 이슈
- #4 #5 

# 작업의 결과물
## Extension과 메인 앱 간의 CoreData 연결
App Group Identifier에 해당하는 identifier와 db에 대해 동일한 이름을 사용하여, 두 앱에서 동일한 저장 공간에 접근해 데이터를 공유할 수 있다.
```swift
enum CoreData {
    static let identifier = "group.com.led.InsightCapture"
    static let databaseName = "InsightDataModel.sqlite"
}
```

FileManager의 containerURL을 통해 Extension에서 가져온 데이터를 변경한 경우에는 저장 시 file location이 달라지기 때문에, 코어데이터를 잘 저장했다고 해도 불러올 때 변경사항이 바로 반영되지 않는다. 따라서, FileManager를 통해 변경된 데이터들을 반영해주는 작업이 필요하며, 이를 `migrateStore()`로 처리한다.

[migration에 대한  참고자료](https://www.appsloveworld.com/swift/100/90/load-data-from-core-data-to-today-widget)

`migrateStore()`을 사용해주어야 Extension과 메인 앱이 동일한 CoreData Container를 통해 동일한 데이터를 공유할 수 있다. Share 뿐만 아니라, Widget Extension에서도 동일하다!!

```swift
    private var oldStoreURL: URL {
        guard let directory = FileManager.default.urls(
            for: .applicationSupportDirectory,
            in: .userDomainMask)
            .first
        else {
            return URL(fileURLWithPath: "")
        }
        return directory.appendingPathComponent(CoreData.databaseName)
    }
    
    private var sharedStoreURL: URL {
        guard let container = FileManager.default.containerURL(
            forSecurityApplicationGroupIdentifier: CoreData.identifier)
        else {
            return URL(fileURLWithPath: "")
        }
        return container.appendingPathComponent(CoreData.databaseName)
    }

    func migrateStore() {
        let coordinator = container.persistentStoreCoordinator
        guard let oldStore = coordinator.persistentStore(for: oldStoreURL) else { return }
        do {
            let _ = try coordinator.migratePersistentStore(oldStore, to: sharedStoreURL, type: .sqlite)
        } catch {
            print(error.localizedDescription)
        }
        do {
            try FileManager.default.removeItem(at: oldStoreURL)
        } catch {
            print(error.localizedDescription)
        }
    }
```

https://www.appsloveworld.com/swift/100/90/load-data-from-core-data-to-today-widget

Close #4 #5 
