### PR TITLE
✨[#11] 기록하기 페이지 뷰 구현

### DIFF
--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		3480CE9B29DABFC000649B6D /* QuoteSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3480CE9A29DABFC000649B6D /* QuoteSourceView.swift */; };
 		3480CE9C29DACE8C00649B6D /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9429D1DEBE003401CE /* Color+.swift */; };
 		3480CE9E29DAE55B00649B6D /* ImageSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3480CE9D29DAE55B00649B6D /* ImageSourceView.swift */; };
+		3480CEA629DC02EA00649B6D /* SwiftUIImageViewer in Frameworks */ = {isa = PBXBuildFile; productRef = 3480CEA529DC02EA00649B6D /* SwiftUIImageViewer */; };
 		34C8FD9529D1DEBE003401CE /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9429D1DEBE003401CE /* Color+.swift */; };
 		34C8FD9729D26CA7003401CE /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9629D26CA7003401CE /* Date+.swift */; };
 		34C8FD9B29D2C43B003401CE /* InsightListCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9A29D2C43B003401CE /* InsightListCardView.swift */; };
@@ -123,6 +124,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				3480CEA629DC02EA00649B6D /* SwiftUIImageViewer in Frameworks */,
 				34624F1029C1C11400518FB4 /* SnapKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -307,6 +309,7 @@
 			name = InsightCapture;
 			packageProductDependencies = (
 				34624F0F29C1C11400518FB4 /* SnapKit */,
+				3480CEA529DC02EA00649B6D /* SwiftUIImageViewer */,
 			);
 			productName = InsightCapture;
 			productReference = 346FAD8329B718B3004CEE9B /* InsightCapture.app */;
@@ -341,6 +344,7 @@
 			mainGroup = 346FAD7A29B718B3004CEE9B;
 			packageReferences = (
 				34624F0E29C1C11400518FB4 /* XCRemoteSwiftPackageReference "SnapKit" */,
+				3480CEA429DC02EA00649B6D /* XCRemoteSwiftPackageReference "swiftui-image-viewer" */,
 			);
 			productRefGroup = 346FAD8429B718B3004CEE9B /* Products */;
 			projectDirPath = "";
@@ -715,6 +719,14 @@
 				kind = branch;
 			};
 		};
+		3480CEA429DC02EA00649B6D /* XCRemoteSwiftPackageReference "swiftui-image-viewer" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/fuzzzlove/swiftui-image-viewer.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.0.0;
+			};
+		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -727,6 +739,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 34624F0E29C1C11400518FB4 /* XCRemoteSwiftPackageReference "SnapKit" */;
 			productName = SnapKit;
+		};
+		3480CEA529DC02EA00649B6D /* SwiftUIImageViewer */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 3480CEA429DC02EA00649B6D /* XCRemoteSwiftPackageReference "swiftui-image-viewer" */;
+			productName = SwiftUIImageViewer;
 		};
 /* End XCSwiftPackageProductDependency section */
 

--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -36,6 +36,11 @@
 		34C8FD9F29D2C56A003401CE /* InsightListCardViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9E29D2C56A003401CE /* InsightListCardViewModel.swift */; };
 		34C8FDA229D30226003401CE /* MyPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDA129D30226003401CE /* MyPageView.swift */; };
 		34C8FDA529D30CE3003401CE /* AddInsightView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDA429D30CE3003401CE /* AddInsightView.swift */; };
+		34C8FDA829D31C1C003401CE /* InsightPageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDA729D31C1C003401CE /* InsightPageView.swift */; };
+		34C8FDAA29D31C26003401CE /* InsightPageViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDA929D31C26003401CE /* InsightPageViewModel.swift */; };
+		34C8FDAC29D40D79003401CE /* OffsetModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDAB29D40D79003401CE /* OffsetModifier.swift */; };
+		34C8FDAE29D42732003401CE /* UINavigationController+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDAD29D42732003401CE /* UINavigationController+.swift */; };
+		34C8FDB029D42FFF003401CE /* View+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FDAF29D42FFF003401CE /* View+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -89,6 +94,11 @@
 		34C8FD9E29D2C56A003401CE /* InsightListCardViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightListCardViewModel.swift; sourceTree = "<group>"; };
 		34C8FDA129D30226003401CE /* MyPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyPageView.swift; sourceTree = "<group>"; };
 		34C8FDA429D30CE3003401CE /* AddInsightView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AddInsightView.swift; sourceTree = "<group>"; };
+		34C8FDA729D31C1C003401CE /* InsightPageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightPageView.swift; sourceTree = "<group>"; };
+		34C8FDA929D31C26003401CE /* InsightPageViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightPageViewModel.swift; sourceTree = "<group>"; };
+		34C8FDAB29D40D79003401CE /* OffsetModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OffsetModifier.swift; sourceTree = "<group>"; };
+		34C8FDAD29D42732003401CE /* UINavigationController+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UINavigationController+.swift"; sourceTree = "<group>"; };
+		34C8FDAF29D42FFF003401CE /* View+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -135,6 +145,8 @@
 				34624F3F29CB300A00518FB4 /* UIColor+.swift */,
 				34C8FD9429D1DEBE003401CE /* Color+.swift */,
 				34C8FD9629D26CA7003401CE /* Date+.swift */,
+				34C8FDAD29D42732003401CE /* UINavigationController+.swift */,
+				34C8FDAF29D42FFF003401CE /* View+.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -193,6 +205,7 @@
 				346FAD8829B718B3004CEE9B /* ContentView.swift */,
 				34C8FDA329D30B37003401CE /* AddInsightView */,
 				34C8FDA029D30212003401CE /* MyPageView */,
+				34C8FDA629D31B82003401CE /* InsightPageView */,
 				34624F5A29D1330E00518FB4 /* InsightListView */,
 				346FAD8A29B718B4004CEE9B /* Assets.xcassets */,
 				346FAD8C29B718B4004CEE9B /* Preview Content */,
@@ -211,6 +224,7 @@
 		34C8FD9329D1565F003401CE /* UIComponents */ = {
 			isa = PBXGroup;
 			children = (
+				34C8FDAB29D40D79003401CE /* OffsetModifier.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -229,6 +243,15 @@
 				34C8FDA429D30CE3003401CE /* AddInsightView.swift */,
 			);
 			path = AddInsightView;
+			sourceTree = "<group>";
+		};
+		34C8FDA629D31B82003401CE /* InsightPageView */ = {
+			isa = PBXGroup;
+			children = (
+				34C8FDA729D31C1C003401CE /* InsightPageView.swift */,
+				34C8FDA929D31C26003401CE /* InsightPageViewModel.swift */,
+			);
+			path = InsightPageView;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -356,7 +379,11 @@
 			buildActionMask = 2147483647;
 			files = (
 				34C8FD9729D26CA7003401CE /* Date+.swift in Sources */,
+				34C8FDAE29D42732003401CE /* UINavigationController+.swift in Sources */,
 				34624F4A29CCA13D00518FB4 /* InsightData+CoreDataProperties.swift in Sources */,
+				34C8FDAA29D31C26003401CE /* InsightPageViewModel.swift in Sources */,
+				34C8FDB029D42FFF003401CE /* View+.swift in Sources */,
+				34C8FDAC29D40D79003401CE /* OffsetModifier.swift in Sources */,
 				34C8FDA229D30226003401CE /* MyPageView.swift in Sources */,
 				34C8FD9529D1DEBE003401CE /* Color+.swift in Sources */,
 				34624F4929CCA13D00518FB4 /* InsightData+CoreDataClass.swift in Sources */,
@@ -365,6 +392,7 @@
 				346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */,
 				346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */,
 				34C8FDA529D30CE3003401CE /* AddInsightView.swift in Sources */,
+				34C8FDA829D31C1C003401CE /* InsightPageView.swift in Sources */,
 				34624F4529CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 				34C8FD9D29D2C47D003401CE /* InsightListViewModel.swift in Sources */,
 				34624F4C29CCA22C00518FB4 /* CoreDataManager.swift in Sources */,

--- a/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
+++ b/InsightCapture/InsightCapture.xcodeproj/project.pbxproj
@@ -29,6 +29,11 @@
 		346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 346FAD8829B718B3004CEE9B /* ContentView.swift */; };
 		346FAD8B29B718B4004CEE9B /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8A29B718B4004CEE9B /* Assets.xcassets */; };
 		346FAD8E29B718B4004CEE9B /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 346FAD8D29B718B4004CEE9B /* Preview Assets.xcassets */; };
+		3480CE9729DA85F300649B6D /* InsightSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3480CE9629DA85F300649B6D /* InsightSourceView.swift */; };
+		3480CE9929DA941800649B6D /* URLSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3480CE9829DA941800649B6D /* URLSourceView.swift */; };
+		3480CE9B29DABFC000649B6D /* QuoteSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3480CE9A29DABFC000649B6D /* QuoteSourceView.swift */; };
+		3480CE9C29DACE8C00649B6D /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9429D1DEBE003401CE /* Color+.swift */; };
+		3480CE9E29DAE55B00649B6D /* ImageSourceView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3480CE9D29DAE55B00649B6D /* ImageSourceView.swift */; };
 		34C8FD9529D1DEBE003401CE /* Color+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9429D1DEBE003401CE /* Color+.swift */; };
 		34C8FD9729D26CA7003401CE /* Date+.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9629D26CA7003401CE /* Date+.swift */; };
 		34C8FD9B29D2C43B003401CE /* InsightListCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34C8FD9A29D2C43B003401CE /* InsightListCardView.swift */; };
@@ -87,6 +92,10 @@
 		346FAD8829B718B3004CEE9B /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		346FAD8A29B718B4004CEE9B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		346FAD8D29B718B4004CEE9B /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
+		3480CE9629DA85F300649B6D /* InsightSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightSourceView.swift; sourceTree = "<group>"; };
+		3480CE9829DA941800649B6D /* URLSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLSourceView.swift; sourceTree = "<group>"; };
+		3480CE9A29DABFC000649B6D /* QuoteSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuoteSourceView.swift; sourceTree = "<group>"; };
+		3480CE9D29DAE55B00649B6D /* ImageSourceView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageSourceView.swift; sourceTree = "<group>"; };
 		34C8FD9429D1DEBE003401CE /* Color+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Color+.swift"; sourceTree = "<group>"; };
 		34C8FD9629D26CA7003401CE /* Date+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Date+.swift"; sourceTree = "<group>"; };
 		34C8FD9A29D2C43B003401CE /* InsightListCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InsightListCardView.swift; sourceTree = "<group>"; };
@@ -225,6 +234,9 @@
 			isa = PBXGroup;
 			children = (
 				34C8FDAB29D40D79003401CE /* OffsetModifier.swift */,
+				3480CE9829DA941800649B6D /* URLSourceView.swift */,
+				3480CE9A29DABFC000649B6D /* QuoteSourceView.swift */,
+				3480CE9D29DAE55B00649B6D /* ImageSourceView.swift */,
 			);
 			path = UIComponents;
 			sourceTree = "<group>";
@@ -250,6 +262,7 @@
 			children = (
 				34C8FDA729D31C1C003401CE /* InsightPageView.swift */,
 				34C8FDA929D31C26003401CE /* InsightPageViewModel.swift */,
+				3480CE9629DA85F300649B6D /* InsightSourceView.swift */,
 			);
 			path = InsightPageView;
 			sourceTree = "<group>";
@@ -365,6 +378,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				34624F5129CCA3F400518FB4 /* InsightData+CoreDataProperties.swift in Sources */,
+				3480CE9C29DACE8C00649B6D /* Color+.swift in Sources */,
 				34624F5029CCA3F000518FB4 /* InsightData+CoreDataClass.swift in Sources */,
 				34624F3029CAE57D00518FB4 /* ShareViewController.swift in Sources */,
 				34624F4129CB302F00518FB4 /* UIColor+.swift in Sources */,
@@ -380,6 +394,7 @@
 			files = (
 				34C8FD9729D26CA7003401CE /* Date+.swift in Sources */,
 				34C8FDAE29D42732003401CE /* UINavigationController+.swift in Sources */,
+				3480CE9B29DABFC000649B6D /* QuoteSourceView.swift in Sources */,
 				34624F4A29CCA13D00518FB4 /* InsightData+CoreDataProperties.swift in Sources */,
 				34C8FDAA29D31C26003401CE /* InsightPageViewModel.swift in Sources */,
 				34C8FDB029D42FFF003401CE /* View+.swift in Sources */,
@@ -390,14 +405,17 @@
 				34624F5C29D1335800518FB4 /* InsightListView.swift in Sources */,
 				34C8FD9B29D2C43B003401CE /* InsightListCardView.swift in Sources */,
 				346FAD8929B718B3004CEE9B /* ContentView.swift in Sources */,
+				3480CE9729DA85F300649B6D /* InsightSourceView.swift in Sources */,
 				346FAD8729B718B3004CEE9B /* InsightCaptureApp.swift in Sources */,
 				34C8FDA529D30CE3003401CE /* AddInsightView.swift in Sources */,
 				34C8FDA829D31C1C003401CE /* InsightPageView.swift in Sources */,
+				3480CE9929DA941800649B6D /* URLSourceView.swift in Sources */,
 				34624F4529CC9FDA00518FB4 /* InsightDataModel.xcdatamodeld in Sources */,
 				34C8FD9D29D2C47D003401CE /* InsightListViewModel.swift in Sources */,
 				34624F4C29CCA22C00518FB4 /* CoreDataManager.swift in Sources */,
 				34624F5329CEDD9E00518FB4 /* Insight.swift in Sources */,
 				34624F4029CB300A00518FB4 /* UIColor+.swift in Sources */,
+				3480CE9E29DAE55B00649B6D /* ImageSourceView.swift in Sources */,
 				34C8FD9F29D2C56A003401CE /* InsightListCardViewModel.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/InsightCapture/InsightCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/InsightCapture/InsightCapture.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -8,6 +8,15 @@
         "branch" : "develop",
         "revision" : "58320fe80522414bf3a7e24c88123581dc586752"
       }
+    },
+    {
+      "identity" : "swiftui-image-viewer",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/fuzzzlove/swiftui-image-viewer.git",
+      "state" : {
+        "revision" : "ca77123064ae046eac2be01654ee756085c2b182",
+        "version" : "1.0.0"
+      }
     }
   ],
   "version" : 2

--- a/InsightCapture/InsightCapture/CoreData/Insight.swift
+++ b/InsightCapture/InsightCapture/CoreData/Insight.swift
@@ -17,12 +17,13 @@ class Insight {
     public var image: Data?
     public var quote: String?
     
-    init(url: URL, text: String, title: String) {
+    init(url: URL, text: String, title: String, thumbnailImage: UIImage? = nil) {
         self.type = InsightType.url.rawValue
         self.text = text
         self.createdDate = Date()
         self.title = title
         self.urlString = url.absoluteString
+        self.image = thumbnailImage?.pngData()
     }
     
     init(image: UIImage, text: String, title: String) {
@@ -34,7 +35,7 @@ class Insight {
     }
     
     init(quote: String, text: String, title: String) {
-        self.type = InsightType.image.rawValue
+        self.type = InsightType.quote.rawValue
         self.createdDate = Date()
         self.title = title == "" ? "NO_title" : title
         self.text = text == "" ? "NO_Content" : text

--- a/InsightCapture/InsightCapture/CoreData/InsightDataModel.xcdatamodeld/InsightDataModel.xcdatamodel/contents
+++ b/InsightCapture/InsightCapture/CoreData/InsightDataModel.xcdatamodeld/InsightDataModel.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21513" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="21754" systemVersion="22D68" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="">
     <entity name="InsightData" representedClassName="InsightData" syncable="YES">
         <attribute name="createdDate" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="image" optional="YES" attributeType="Binary"/>

--- a/InsightCapture/InsightCapture/Extensions/Date+.swift
+++ b/InsightCapture/InsightCapture/Extensions/Date+.swift
@@ -8,7 +8,7 @@
 import Foundation
 
 extension Date {
-    public func createCardDateString() -> String {
+    public func toCardDateString() -> String {
         let formatter = DateComponentsFormatter()
         formatter.allowedUnits = [.day, .hour, .minute, .second]
         formatter.maximumUnitCount = 1
@@ -49,5 +49,12 @@ extension Date {
         }
         
         return result
+    }
+    
+    public func toPageDateString() -> String {
+        let dateFormatter = DateFormatter()
+        dateFormatter.dateFormat = "yyyy-MM-dd"
+        
+        return dateFormatter.string(from: self)
     }
 }

--- a/InsightCapture/InsightCapture/Extensions/UINavigationController+.swift
+++ b/InsightCapture/InsightCapture/Extensions/UINavigationController+.swift
@@ -1,0 +1,22 @@
+//
+//  UINavigationController.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/29.
+//
+
+// 출처 : https://medium.com/hcleedev/swift-custom-navigationview에서-swipe-back-가능하게-하기-c3c519c59bcb
+// UINavigationController의 extension으로 viewdidload를 수정하여, SwiftUI의 Navigation에서 pop gesture가 가능하게 만들어줍니다.
+
+import UIKit
+
+extension UINavigationController: ObservableObject, UIGestureRecognizerDelegate {
+    override open func viewDidLoad() {
+        super.viewDidLoad()
+        interactivePopGestureRecognizer?.delegate = self
+    }
+
+    public func gestureRecognizerShouldBegin(_ gestureRecognizer: UIGestureRecognizer) -> Bool {
+        return viewControllers.count > 1
+    }
+}

--- a/InsightCapture/InsightCapture/Extensions/View+.swift
+++ b/InsightCapture/InsightCapture/Extensions/View+.swift
@@ -1,0 +1,26 @@
+//
+//  View+.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/29.
+//
+
+import SwiftUI
+
+extension View {
+    func cornerRadius(_ radius: CGFloat, corners: UIRectCorner) -> some View {
+        clipShape( RoundedCorner(radius: radius, corners: corners) )
+    }
+}
+
+
+struct RoundedCorner: Shape {
+
+    var radius: CGFloat = .infinity
+    var corners: UIRectCorner = .allCorners
+
+    func path(in rect: CGRect) -> Path {
+        let path = UIBezierPath(roundedRect: rect, byRoundingCorners: corners, cornerRadii: CGSize(width: radius, height: radius))
+        return Path(path.cgPath)
+    }
+}

--- a/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
+++ b/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
@@ -14,7 +14,7 @@ struct InsightListCardView: View {
     var body: some View {
             VStack {
                 HStack {
-                    Text(viewModel.insight.createdDate!.createCardDateString())
+                    Text(viewModel.insight.createdDate!.toCardDateString())
                         .font(Font.system(size: 13, weight: .medium))
                     
                     Spacer()

--- a/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
+++ b/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
@@ -10,145 +10,149 @@ import LinkPresentation
 
 struct InsightListCardView: View {
     @StateObject var viewModel: InsightListCardViewModel
-
+    
     var body: some View {
-        VStack {
-            HStack {
-                Text(viewModel.insight.createdDate!.createCardDateString())
-                    .font(Font.system(size: 13, weight: .medium))
-                
-                Spacer()
-                Button {
-                    // 더 보기 액션 구현하기
-                } label: {
-                    Image(systemName: "ellipsis")
+            VStack {
+                HStack {
+                    Text(viewModel.insight.createdDate!.createCardDateString())
                         .font(Font.system(size: 13, weight: .medium))
-                        .foregroundColor(.black)
-                }
-            }
-            .padding(.horizontal, 12)
-            .padding(.top, 12)
-            .padding(.bottom, 6)
-            
-            VStack(alignment: .leading) {
-                switch(viewModel.insight.type) {
-                case InsightType.image.rawValue:
-                    ZStack {
-                        if viewModel.insight.image == nil {
-                            Text("이미지 없음")
-                        } else {
-                            Image(uiImage: UIImage(data: viewModel.insight.image!)!)
-                                .resizable()
-                                .frame(width: UIScreen.main.bounds.size.width - 32 - 16, height: (UIScreen.main.bounds.size.width - 32 - 16) * 0.56)
-                                .cornerRadius(8)
-                                .clipped()
-                        }
-                    }
-                    .padding(.horizontal, 8)
                     
-                case InsightType.url.rawValue:
-                    ZStack {
-                        HStack {
-                            if viewModel.urlImage != nil {
-                                Image(uiImage: viewModel.urlImage!)
-                                    .resizable()
-                                    .frame(width: 136, height: 76)
-                                    .clipped()
+                    Spacer()
+                    Button {
+                        // 더 보기 액션 구현하기
+                    } label: {
+                        Image(systemName: "ellipsis")
+                            .font(Font.system(size: 13, weight: .medium))
+                            .foregroundColor(.black)
+                    }
+                }
+                .padding(.horizontal, 12)
+                .padding(.top, 12)
+                .padding(.bottom, 6)
+                
+                VStack(alignment: .leading) {
+                    switch(viewModel.insight.type) {
+                    case InsightType.image.rawValue:
+                        ZStack {
+                            if viewModel.insight.image == nil {
+                                Text("이미지 없음")
                             } else {
-                                Rectangle()
-                                    .foregroundColor(.clear)
-                                    .frame(width: 136, height: 76)
+                                Image(uiImage: UIImage(data: viewModel.insight.image!)!)
+                                    .resizable()
+                                    .frame(width: UIScreen.main.bounds.size.width - 32 - 16, height: (UIScreen.main.bounds.size.width - 32 - 16) * 0.56)
+                                    .cornerRadius(8)
+                                    .clipped()
                             }
-                            
-                            VStack(alignment: .leading) {
-                                Text(viewModel.urlTitle ?? "")
-                                    .font(Font.system(size: 15, weight: .bold))
-                                    .lineLimit(2)
-                                    .padding(.vertical, 2)
+                        }
+                        .padding(.horizontal, 8)
+                        
+                    case InsightType.url.rawValue:
+                        ZStack {
+                            HStack {
+                                if viewModel.urlImage != nil {
+                                    Image(uiImage: viewModel.urlImage!)
+                                        .resizable()
+                                        .frame(width: 136, height: 76)
+                                        .clipped()
+                                } else {
+                                    Rectangle()
+                                        .foregroundColor(.clear)
+                                        .frame(width: 136, height: 76)
+                                }
                                 
-                                Text(viewModel.urlDescription ?? "")
-                                    .font(Font.system(size: 12, weight: .light))
-                                    .lineLimit(1)
-                                    .foregroundColor(.gray)
+                                VStack(alignment: .leading) {
+                                    Text(viewModel.urlTitle ?? "")
+                                        .font(Font.system(size: 15, weight: .bold))
+                                        .lineLimit(2)
+                                        .padding(.vertical, 2)
+                                    
+                                    Text(viewModel.urlDescription ?? "")
+                                        .font(Font.system(size: 12, weight: .light))
+                                        .lineLimit(1)
+                                        .foregroundColor(.gray)
+                                    
+                                    HStack {
+                                        Spacer()
+                                    }
+                                }
+                                .padding(.horizontal, 3)
+                            }
+                            .padding(.all, 8)
+                            .background(Color(uiColor: UIColor.systemGray5))
+                            .cornerRadius(10)
+                            
+                            if viewModel.urlImage == nil {
+                                ProgressView()
+                            }
+                        }
+                        .padding(.horizontal, 8)
+                        
+                    case InsightType.quote.rawValue:
+                        ZStack {
+                            Rectangle()
+                                .foregroundColor(Color.randomColor(from: viewModel.insight.createdDate ?? Date()))
+                                .padding(.horizontal, 50)
+                            
+                            VStack {
+                                Image(systemName: "quote.opening")
+                                    .padding(.top, 8)
+                                
+                                Text(viewModel.insight.quote ?? "")
+                                    .font(Font.system(size: 16, weight: .medium))
+                                    .lineLimit(3)
+                                    .padding(.top, 8)
+                                    .padding(.bottom, 16)
                                 
                                 HStack {
                                     Spacer()
                                 }
                             }
-                            .padding(.horizontal, 3)
+                            .padding(.all, 8)
+                            .cornerRadius(10)
                         }
-                        .padding(.all, 8)
-                        .background(Color(uiColor: UIColor.systemGray5))
-                        .cornerRadius(10)
+                        .padding(.horizontal, 8)
                         
-                        if viewModel.urlImage == nil {
-                            ProgressView()
-                        }
-                    }
-                    .padding(.horizontal, 8)
-                    
-                case InsightType.quote.rawValue:
-                    ZStack {
-                        Rectangle()
-                            .foregroundColor(Color.randomColor(from: viewModel.insight.createdDate ?? Date()))
-                            .padding(.horizontal, 50)
+                    case InsightType.brain.rawValue:
+                        EmptyView()
                         
-                        VStack {
-                            Image(systemName: "quote.opening")
-                                .padding(.top, 8)
-                            
-                            Text(viewModel.insight.quote ?? "")
-                                .font(Font.system(size: 16, weight: .medium))
-                                .lineLimit(3)
-                                .padding(.top, 8)
-                                .padding(.bottom, 16)
-                            
-                            HStack {
-                                Spacer()
-                            }
-                        }
-                        .padding(.all, 8)
-                        .cornerRadius(10)
+                    default:
+                        EmptyView()
                     }
-                    .padding(.horizontal, 8)
                     
-                case InsightType.brain.rawValue:
-                    EmptyView()
+                    Text(viewModel.insight.title!)
+                        .font(Font.system(size: 16, weight: .semibold))
+                        .lineLimit(1)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 4)
                     
-                default:
-                    EmptyView()
-                }
-                
-                Text(viewModel.insight.title!)
-                    .font(Font.system(size: 16, weight: .semibold))
-                    .lineLimit(1)
-                    .padding(.horizontal, 12)
-                    .padding(.bottom, 4)
-                
-                Text(viewModel.insight.text!)
-                    .font(Font.system(size: 16, weight: .medium))
-                    .lineLimit(3)
+                    Text(viewModel.insight.text!)
+                        .font(Font.system(size: 16, weight: .medium))
+                        .lineLimit(3)
+                        .padding(.horizontal, 12)
+                        .padding(.bottom, 16)
+                    
+                    HStack {
+                        Spacer()
+                        Text("자세히 보기")
+                            .font(Font.system(size: 13, weight: .medium))
+                    }
                     .padding(.horizontal, 12)
                     .padding(.bottom, 16)
-                
-                HStack {
-                    Spacer()
-                    Text("자세히 보기")
-                        .font(Font.system(size: 13, weight: .medium))
                 }
-                .padding(.horizontal, 12)
-                .padding(.bottom, 16)
+                .onTapGesture {
+                    viewModel.tapCard()
+                }
             }
-            .onTapGesture {
-                // 눌렀을 때의 Action
+            .navigationDestination(isPresented: $viewModel.isShowingInsightPageView, destination: {
+                InsightPageView(viewModel: InsightPageViewModel(insight: viewModel.insight))
+
+            })
+            .background {
+                Rectangle()
+                    .foregroundColor(.white)
+                    .cornerRadius(8)
+                    .shadow(color: .init(uiColor: UIColor(white: 0, alpha: 0.25)), radius: 4, x: 0, y: 1)
             }
-        }
-        .background {
-            Rectangle()
-                .foregroundColor(.white)
-                .cornerRadius(8)
-                .shadow(color: .init(uiColor: UIColor(white: 0, alpha: 0.25)), radius: 4, x: 0, y: 1)
-        }
         .padding(.horizontal, 16)
     }
 }

--- a/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
+++ b/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
@@ -40,6 +40,7 @@ struct InsightListCardView: View {
                             } else {
                                 Image(uiImage: UIImage(data: viewModel.insight.image!)!)
                                     .resizable()
+                                    .scaledToFill()
                                     .frame(width: UIScreen.main.bounds.size.width - 32 - 16, height: (UIScreen.main.bounds.size.width - 32 - 16) * 0.56)
                                     .cornerRadius(8)
                                     .clipped()

--- a/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
+++ b/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
@@ -12,6 +12,7 @@ struct InsightListCardView: View {
     @StateObject var viewModel: InsightListCardViewModel
     
     var body: some View {
+        if viewModel.insight.title != nil {
             VStack {
                 HStack {
                     Text(viewModel.insight.createdDate!.toCardDateString())
@@ -146,7 +147,7 @@ struct InsightListCardView: View {
             }
             .navigationDestination(isPresented: $viewModel.isShowingInsightPageView, destination: {
                 InsightPageView(viewModel: InsightPageViewModel(insight: viewModel.insight))
-
+                
             })
             .background {
                 Rectangle()
@@ -154,6 +155,7 @@ struct InsightListCardView: View {
                     .cornerRadius(8)
                     .shadow(color: .init(uiColor: UIColor(white: 0, alpha: 0.25)), radius: 4, x: 0, y: 1)
             }
-        .padding(.horizontal, 16)
+            .padding(.horizontal, 16)
+        }
     }
 }

--- a/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
+++ b/InsightCapture/InsightCapture/InsightListView/InsightListCardView.swift
@@ -35,7 +35,7 @@ struct InsightListCardView: View {
                     case InsightType.image.rawValue:
                         ZStack {
                             if viewModel.insight.image == nil {
-                                Text("이미지 없음")
+                                // 이미지가 없는 경우
                             } else {
                                 Image(uiImage: UIImage(data: viewModel.insight.image!)!)
                                     .resizable()
@@ -92,6 +92,7 @@ struct InsightListCardView: View {
                             Rectangle()
                                 .foregroundColor(Color.randomColor(from: viewModel.insight.createdDate ?? Date()))
                                 .padding(.horizontal, 50)
+                                .padding(.vertical, 8)
                             
                             VStack {
                                 Image(systemName: "quote.opening")

--- a/InsightCapture/InsightCapture/InsightListView/InsightListCardViewModel.swift
+++ b/InsightCapture/InsightCapture/InsightListView/InsightListCardViewModel.swift
@@ -16,6 +16,8 @@ class InsightListCardViewModel: ObservableObject  {
     @Published var urlTitle: String?
     @Published var urlDescription: String?
     
+    @Published var isShowingInsightPageView: Bool = false
+    
     init(insight: InsightData) {
         self.insight = insight
         
@@ -43,5 +45,7 @@ class InsightListCardViewModel: ObservableObject  {
         }
     }
     
-    
+    func tapCard() {
+        isShowingInsightPageView = true
+    }
 }

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
@@ -45,15 +45,20 @@ struct InsightPageView: View {
                     .zIndex(2)
                     
                     VStack {
-                        VStack {
+                        VStack(spacing: 24) {
+                            // 날짜
                             Text(viewModel.insight.createdDate?.toPageDateString() ?? "")
                                 .font(Font.system(size: 13, weight: .medium))
-                                .padding(.bottom, 24)
                             
+                            // 본문 컨텐츠
                             Text(viewModel.insight.text ?? "")
                                 .multilineTextAlignment(.center)
                                 .font(Font.system(size: 16, weight: .medium))
                             
+                            // 인사이트 source
+                            InsightSourceView(viewModel: viewModel)
+                            
+                            // 하단 여백
                             Spacer()
                                 .frame(height: 100)
                         }
@@ -76,11 +81,7 @@ struct InsightPageView: View {
                 }
                 .modifier(OffsetModifier(offset: $viewModel.offset))
             }
-            .background {
-                
-            }
         }
-        //        .background(Color.mint)
         .coordinateSpace(name: "SCROLL")
         .ignoresSafeArea()
         .navigationBarBackButtonHidden(true)
@@ -164,3 +165,4 @@ struct TopBar: View {
         return progress
     }
 }
+

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
@@ -125,7 +125,7 @@ struct TopBar: View {
     
     
     @Binding var offset: CGFloat
-    @ObservedObject var viewModel: InsightPageViewModel
+    @StateObject var viewModel: InsightPageViewModel
     
     var body: some View {
         VStack{

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
@@ -1,0 +1,170 @@
+//
+//  InsightPageView.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/28.
+//
+
+import SwiftUI
+
+struct InsightPageView: View {
+    @StateObject var viewModel: InsightPageViewModel
+    @State var offset: CGFloat = 0
+    
+    @Environment(\.dismiss) var dismiss
+    @Environment(\.presentationMode) var mode: Binding<PresentationMode>
+    
+    @GestureState private var dragOffset = CGSize.zero
+    
+    let maxHeight = UIScreen.main.bounds.height / 2.6
+    let topEdge: CGFloat = 15
+    
+    var body: some View {
+        ZStack(alignment: .top) {
+            ScrollView(.vertical, showsIndicators: false) {
+                VStack {
+                    GeometryReader { proxy in
+                        TopBar(maxHeight: maxHeight, offset: $viewModel.offset, viewModel: viewModel)
+                            .frame(maxWidth: .infinity)
+                            .frame(height: getHeaderHeight(), alignment: .bottom)
+                            .background {
+                                Color.mint
+                            }
+                    }
+                    .frame(height: maxHeight)
+                    .offset(y: -viewModel.offset)
+                    .zIndex(1)
+                    
+                    VStack {
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                        Text("Hello, World")
+                            .frame(height: 100)
+                    }
+                    .zIndex(0)
+                }
+                .modifier(OffsetModifier(offset: $viewModel.offset))
+            }
+        }
+        .background(Color.gray)
+        .coordinateSpace(name: "SCROLL")
+        .ignoresSafeArea()
+        .navigationBarBackButtonHidden(true)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarLeading) {
+                Button {
+                    dismiss()
+                } label: {
+                    Image(systemName: "arrow.left")
+                        .foregroundColor(.black)
+                        .font(Font.system(size: 16, weight: .medium))
+                }
+            }
+            
+            ToolbarItem(placement: .principal) {
+                Text(viewModel.insight.title ?? "")
+                    .lineLimit(1)
+                    .font(Font.system(size: 16, weight: .medium))
+                    .opacity(getToolbarTitleOpacity() )
+            }
+            
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Button {
+                    //
+                } label: {
+                    Image(systemName: "ellipsis")
+                        .foregroundColor(.black)
+                        .font(Font.system(size: 16, weight: .medium))
+                }
+            }
+        }
+        //210에서 색 보여주기
+        .toolbarBackground(.hidden, for: .navigationBar)
+    }
+    
+    func getHeaderHeight() -> CGFloat {
+        let topHeight = maxHeight + viewModel.offset
+        
+        return max(topHeight, 80 + topEdge)
+    }
+    
+    func getTopBarTitleOpacity() -> CGFloat {
+        let progress = -(viewModel.offset + 120 ) / (maxHeight - (80 + topEdge) - 150)
+        
+        return progress
+    }
+    
+    func getToolbarTitleOpacity() -> CGFloat {
+        let progress = -(viewModel.offset + 120) / (maxHeight - (80 + topEdge) - 100)
+        return progress
+    }
+}
+
+struct TopBar: View {
+    let topBarHeight: CGFloat = 120
+    var maxHeight: CGFloat
+    var topEdge: CGFloat = 15
+    
+    
+    @Binding var offset: CGFloat
+    @ObservedObject var viewModel: InsightPageViewModel
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            Text(viewModel.insight.title  ?? "")
+                .lineLimit(2)
+                .multilineTextAlignment(.center)
+                .font(Font.system(size: 24, weight: .semibold))
+                .padding()
+                .opacity(1 - getTopBarTitleOpacity())
+            Divider()
+        }
+        .frame(minWidth: 0, maxWidth: .infinity)
+        .frame(height: 260)
+        .padding(.horizontal, 26)
+        .background(
+            ZStack {
+                VStack {
+                    Spacer()
+                    ZStack {
+                        Rectangle()
+                            .cornerRadius(getCornerRadius(), corners: [.topLeft, .topRight])
+                            .foregroundColor(.white)
+                            .frame(height: topBarHeight)
+                    }
+                }
+            }
+        )
+    }
+    
+    func getCornerRadius() -> CGFloat {
+        let progress = -offset / 110
+        let cornerRadius = (1 - progress) * topBarHeight/2
+        
+//        return offset > 0 ? topBarHeight/2 : (cornerRadius > 0 ? cornerRadius : 0)
+        return topBarHeight/2
+    }
+    
+    func getTopBarTitleOpacity() -> CGFloat {
+        let progress = -(offset + topBarHeight) / (maxHeight - (80 + topEdge) - 200)
+        
+        return progress
+    }
+}

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
@@ -21,8 +21,8 @@ struct InsightPageView: View {
                 ZStack {
                     Color.randomColor(from: viewModel.insight.createdDate ?? Date())
                     
-                    if viewModel.insight.image != nil {
-                        Image(uiImage: UIImage(data: viewModel.insight.image!)!)
+                    if viewModel.image != nil {
+                        Image(uiImage: viewModel.image!)
                             .resizable()
                             .aspectRatio(contentMode: .fill)
                             .clipped()
@@ -61,14 +61,17 @@ struct InsightPageView: View {
                     }
                     .zIndex(1)
                     .background {
-                        VStack {
-                            Rectangle()
-                                .frame(width: UIScreen.main.bounds.width, height: 100, alignment: .center)
-                                .foregroundColor(.white)
-                            
-                            Spacer()
+                        ZStack{
+                            VStack {
+                                Rectangle()
+                                    .frame(width: UIScreen.main.bounds.width, height: 100, alignment: .center)
+                                    .foregroundColor(.white)
+                                
+                                Spacer()
+                            }
+                            .offset(y:-20)
+                            Color.white
                         }
-                        .offset(y:-20)
                     }
                 }
                 .modifier(OffsetModifier(offset: $viewModel.offset))

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
@@ -105,7 +105,7 @@ struct InsightPageView: View {
             
             ToolbarItem(placement: .navigationBarTrailing) {
                 Button {
-                    //
+                    viewModel.isShowingActions = true
                 } label: {
                     Image(systemName: "ellipsis")
                         .foregroundColor(.black)
@@ -113,8 +113,16 @@ struct InsightPageView: View {
                 }
             }
         }
-        //210에서 색 보여주기
         .toolbarBackground(Color.white, for: .navigationBar)
+        .confirmationDialog("인사이트", isPresented: $viewModel.isShowingActions, titleVisibility: .hidden) {
+            Button("수정하기", action: {
+                
+            })
+            Button("삭제하기", role: .destructive, action: {
+                viewModel.deleteInsight()
+                dismiss()
+            })
+        }
     }
 }
 

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageView.swift
@@ -9,60 +9,75 @@ import SwiftUI
 
 struct InsightPageView: View {
     @StateObject var viewModel: InsightPageViewModel
-    @State var offset: CGFloat = 0
     
     @Environment(\.dismiss) var dismiss
     @Environment(\.presentationMode) var mode: Binding<PresentationMode>
     
     @GestureState private var dragOffset = CGSize.zero
     
-    let maxHeight = UIScreen.main.bounds.height / 2.6
-    let topEdge: CGFloat = 15
-    
     var body: some View {
         ZStack(alignment: .top) {
+            VStack{
+                ZStack {
+                    Color.randomColor(from: viewModel.insight.createdDate ?? Date())
+                    
+                    if viewModel.insight.image != nil {
+                        Image(uiImage: UIImage(data: viewModel.insight.image!)!)
+                            .resizable()
+                            .aspectRatio(contentMode: .fill)
+                            .clipped()
+                    }
+                }
+                .frame(width: UIScreen.main.bounds.width, height: viewModel.getHeaderHeight())
+                
+                Spacer()
+            }
+            
             ScrollView(.vertical, showsIndicators: false) {
                 VStack {
                     GeometryReader { proxy in
-                        TopBar(maxHeight: maxHeight, offset: $viewModel.offset, viewModel: viewModel)
+                        TopBar(maxHeight: viewModel.maxHeight, offset: $viewModel.offset, viewModel: viewModel)
                             .frame(maxWidth: .infinity)
-                            .frame(height: getHeaderHeight(), alignment: .bottom)
-                            .background {
-                                Color.mint
-                            }
+                            .frame(height: viewModel.getHeaderHeight(), alignment: .bottom)
                     }
-                    .frame(height: maxHeight)
+                    .frame(height: viewModel.maxHeight)
                     .offset(y: -viewModel.offset)
-                    .zIndex(1)
+                    .zIndex(2)
                     
                     VStack {
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
-                        Text("Hello, World")
-                            .frame(height: 100)
+                        VStack {
+                            Text(viewModel.insight.createdDate?.toPageDateString() ?? "")
+                                .font(Font.system(size: 13, weight: .medium))
+                                .padding(.bottom, 24)
+                            
+                            Text(viewModel.insight.text ?? "")
+                                .multilineTextAlignment(.center)
+                                .font(Font.system(size: 16, weight: .medium))
+                            
+                            Spacer()
+                                .frame(height: 100)
+                        }
+                        .padding(.horizontal, 16)
                     }
-                    .zIndex(0)
+                    .zIndex(1)
+                    .background {
+                        VStack {
+                            Rectangle()
+                                .frame(width: UIScreen.main.bounds.width, height: 100, alignment: .center)
+                                .foregroundColor(.white)
+                            
+                            Spacer()
+                        }
+                        .offset(y:-20)
+                    }
                 }
                 .modifier(OffsetModifier(offset: $viewModel.offset))
             }
+            .background {
+                
+            }
         }
-        .background(Color.gray)
+        //        .background(Color.mint)
         .coordinateSpace(name: "SCROLL")
         .ignoresSafeArea()
         .navigationBarBackButtonHidden(true)
@@ -81,7 +96,7 @@ struct InsightPageView: View {
                 Text(viewModel.insight.title ?? "")
                     .lineLimit(1)
                     .font(Font.system(size: 16, weight: .medium))
-                    .opacity(getToolbarTitleOpacity() )
+                    .opacity(viewModel.getToolbarTitleOpacity() )
             }
             
             ToolbarItem(placement: .navigationBarTrailing) {
@@ -95,24 +110,7 @@ struct InsightPageView: View {
             }
         }
         //210에서 색 보여주기
-        .toolbarBackground(.hidden, for: .navigationBar)
-    }
-    
-    func getHeaderHeight() -> CGFloat {
-        let topHeight = maxHeight + viewModel.offset
-        
-        return max(topHeight, 80 + topEdge)
-    }
-    
-    func getTopBarTitleOpacity() -> CGFloat {
-        let progress = -(viewModel.offset + 120 ) / (maxHeight - (80 + topEdge) - 150)
-        
-        return progress
-    }
-    
-    func getToolbarTitleOpacity() -> CGFloat {
-        let progress = -(viewModel.offset + 120) / (maxHeight - (80 + topEdge) - 100)
-        return progress
+        .toolbarBackground(Color.white, for: .navigationBar)
     }
 }
 
@@ -126,40 +124,35 @@ struct TopBar: View {
     @ObservedObject var viewModel: InsightPageViewModel
     
     var body: some View {
-        VStack {
+        VStack{
             Spacer()
-            Text(viewModel.insight.title  ?? "")
-                .lineLimit(2)
-                .multilineTextAlignment(.center)
-                .font(Font.system(size: 24, weight: .semibold))
-                .padding()
-                .opacity(1 - getTopBarTitleOpacity())
-            Divider()
-        }
-        .frame(minWidth: 0, maxWidth: .infinity)
-        .frame(height: 260)
-        .padding(.horizontal, 26)
-        .background(
+            
             ZStack {
                 VStack {
                     Spacer()
-                    ZStack {
+                    Text(viewModel.insight.title  ?? "")
+                        .frame(alignment: .center)
+                        .multilineTextAlignment(.center)
+                        .lineLimit(2)
+                        .font(Font.system(size: 24, weight: .semibold))
+                        .padding(.horizontal, 20)
+                        .opacity(1 - getTopBarTitleOpacity())
+                    Spacer()
+                }
+                .padding(.top, 30)
+                .frame(width: UIScreen.main.bounds.width, height: topBarHeight)
+                .background {
+                    VStack {
+                        Spacer()
                         Rectangle()
-                            .cornerRadius(getCornerRadius(), corners: [.topLeft, .topRight])
+                            .cornerRadius(60, corners: [.topLeft, .topRight])
                             .foregroundColor(.white)
-                            .frame(height: topBarHeight)
+                            .frame(width: UIScreen.main.bounds.width, height: topBarHeight)
                     }
                 }
             }
-        )
-    }
-    
-    func getCornerRadius() -> CGFloat {
-        let progress = -offset / 110
-        let cornerRadius = (1 - progress) * topBarHeight/2
-        
-//        return offset > 0 ? topBarHeight/2 : (cornerRadius > 0 ? cornerRadius : 0)
-        return topBarHeight/2
+        }
+        .frame(width: UIScreen.main.bounds.width, height: maxHeight)
     }
     
     func getTopBarTitleOpacity() -> CGFloat {

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
@@ -29,7 +29,7 @@ class InsightPageViewModel: ObservableObject {
             image = UIImage(data: insight.image!)!
             
         case InsightType.url.rawValue:
-            getImageFromURL()
+            fetchImage(from: URL(string: insight.urlString ?? "")!)
             
         case InsightType.quote.rawValue:
             let _ = 0
@@ -59,19 +59,17 @@ class InsightPageViewModel: ObservableObject {
         return progress
     }
     
-    func getImageFromURL() {
+    func fetchImage(from url: URL) {
         let provider = LPMetadataProvider()
-        provider.startFetchingMetadata(for: URL(string: insight.urlString ?? "")!) { metaData, error in
-            if let error = error { return }
+        provider.startFetchingMetadata(for: url) { metaData, error in
+            if error == nil { return }
             guard let data = metaData else { return }
             
             data.imageProvider?.loadObject(ofClass: UIImage.self, completionHandler: { image, error in
                 guard error == nil else { return }
                 
                 if let image = image as? UIImage {
-                    DispatchQueue.main.async {
-                        self.image = image
-                    }
+                    self.image = image
                 } else {
                     print("no image available")
                 }

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
@@ -5,19 +5,35 @@
 //  Created by Park Sungmin on 2023/03/28.
 //
 
-import Foundation
+import SwiftUI
 
 class InsightPageViewModel: ObservableObject {
     
     @Published var insight: InsightData
-    @Published var offset: CGFloat {
-        didSet {
-            print(self.offset)
-        }
-    }
+    @Published var offset: CGFloat
+    
+    let maxHeight = UIScreen.main.bounds.height / 2.6
+    let topEdge: CGFloat = 15
     
     init(insight: InsightData) {
         self.insight = insight
         self.offset = 0
+    }
+    
+    func getHeaderHeight() -> CGFloat {
+        let topHeight = maxHeight + offset
+        
+        return max(topHeight, 80 + topEdge)
+    }
+    
+    func getTopBarTitleOpacity() -> CGFloat {
+        let progress = -(offset + 120 ) / (maxHeight - (80 + topEdge) - 150)
+        
+        return progress
+    }
+    
+    func getToolbarTitleOpacity() -> CGFloat {
+        let progress = -(offset + 120) / (maxHeight - (80 + topEdge) - 100)
+        return progress
     }
 }

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
@@ -6,11 +6,16 @@
 //
 
 import SwiftUI
+import LinkPresentation
+import UniformTypeIdentifiers
 
 class InsightPageViewModel: ObservableObject {
     
     @Published var insight: InsightData
     @Published var offset: CGFloat
+    
+    @Published var image: UIImage?
+    
     
     let maxHeight = UIScreen.main.bounds.height / 2.6
     let topEdge: CGFloat = 15
@@ -18,6 +23,23 @@ class InsightPageViewModel: ObservableObject {
     init(insight: InsightData) {
         self.insight = insight
         self.offset = 0
+        
+        switch(insight.type) {
+        case InsightType.image.rawValue:
+            image = UIImage(data: insight.image!)!
+            
+        case InsightType.url.rawValue:
+            getImageFromURL()
+            
+        case InsightType.quote.rawValue:
+            let _ = 0
+            
+        case InsightType.brain.rawValue:
+            let _ = 0
+            
+        default:
+            let _ = 0
+        }
     }
     
     func getHeaderHeight() -> CGFloat {
@@ -35,5 +57,25 @@ class InsightPageViewModel: ObservableObject {
     func getToolbarTitleOpacity() -> CGFloat {
         let progress = -(offset + 120) / (maxHeight - (80 + topEdge) - 100)
         return progress
+    }
+    
+    func getImageFromURL() {
+        let provider = LPMetadataProvider()
+        provider.startFetchingMetadata(for: URL(string: insight.urlString ?? "")!) { metaData, error in
+            if let error = error { return }
+            guard let data = metaData else { return }
+            
+            data.imageProvider?.loadObject(ofClass: UIImage.self, completionHandler: { image, error in
+                guard error == nil else { return }
+                
+                if let image = image as? UIImage {
+                    DispatchQueue.main.async {
+                        self.image = image
+                    }
+                } else {
+                    print("no image available")
+                }
+            })
+        }
     }
 }

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
@@ -1,0 +1,23 @@
+//
+//  InsightPageViewModel.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/28.
+//
+
+import Foundation
+
+class InsightPageViewModel: ObservableObject {
+    
+    @Published var insight: InsightData
+    @Published var offset: CGFloat {
+        didSet {
+            print(self.offset)
+        }
+    }
+    
+    init(insight: InsightData) {
+        self.insight = insight
+        self.offset = 0
+    }
+}

--- a/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightPageViewModel.swift
@@ -15,7 +15,7 @@ class InsightPageViewModel: ObservableObject {
     @Published var offset: CGFloat
     
     @Published var image: UIImage?
-    
+    @Published var isShowingActions: Bool = false
     
     let maxHeight = UIScreen.main.bounds.height / 2.6
     let topEdge: CGFloat = 15
@@ -75,5 +75,9 @@ class InsightPageViewModel: ObservableObject {
                 }
             })
         }
+    }
+    
+    func deleteInsight() {
+        CoreDataManager.shared.deleteInsight(insightData: insight)
     }
 }

--- a/InsightCapture/InsightCapture/InsightPageView/InsightSourceView.swift
+++ b/InsightCapture/InsightCapture/InsightPageView/InsightSourceView.swift
@@ -1,0 +1,47 @@
+//
+//  InsightSourceView.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/04/03.
+//
+
+import SwiftUI
+import LinkPresentation
+
+struct InsightSourceView: View {
+    @ObservedObject var viewModel: InsightPageViewModel
+    
+    @State var title: String = ""
+    @State var desc: String = ""
+    
+    init(viewModel: InsightPageViewModel){
+        self.viewModel = viewModel
+        
+//        if viewModel.insight.type == InsightType.url.rawValue {
+//            let provider = LPMetadataProvider()
+//            provider.startFetchingMetadata(for: URL(string: viewModel.insight.urlString ?? "")!) { metaData, error in
+//                if error != nil { return }
+//                guard let data = metaData else { return }
+//
+////                self.title = data.title ?? ""
+//
+//            }
+//        }
+    }
+    
+    var body: some View {
+        switch (viewModel.insight.type){
+        case InsightType.image.rawValue:
+            ImageSourceView(insight: viewModel.insight)
+            
+        case InsightType.url.rawValue:
+            URLSourceView(insight: viewModel.insight)
+            
+        case InsightType.quote.rawValue:
+            QuoteSourceView(insight: viewModel.insight)
+            
+        default:
+            let _ = 0
+        }
+    }
+}

--- a/InsightCapture/InsightCapture/UIComponents/ImageSourceView.swift
+++ b/InsightCapture/InsightCapture/UIComponents/ImageSourceView.swift
@@ -6,15 +6,38 @@
 //
 
 import SwiftUI
+import SwiftUIImageViewer
 
 struct ImageSourceView: View {
     @State var insight: InsightData
+    @State var isShowingImage: Bool = false
     
     var body: some View {
-        Image(uiImage: UIImage(data: insight.image!)!)
-            .resizable()
-            .scaledToFit()
-            .cornerRadius(18, corners: .allCorners)
+        Button {
+            isShowingImage = true
+        } label: {
+            Image(uiImage: UIImage(data: insight.image!)!)
+                .resizable()
+                .scaledToFit()
+                .cornerRadius(18, corners: .allCorners)
+        }
+        .navigationDestination(isPresented: $isShowingImage) {
+            SwiftUIImageViewer(image: Image(uiImage: UIImage(data: insight.image!)!))
+                .background(Color.black)
+                .navigationBarBackButtonHidden()
+                .toolbarBackground(.hidden, for: .navigationBar)
+                .edgesIgnoringSafeArea(.all)
+//                .preferredColorScheme(.dark)
+                .overlay(alignment: .topLeading) {
+                    Button {
+                        self.isShowingImage = false
+                    } label: {
+                        Label("", systemImage: "arrow.left")
+                            .foregroundColor(.white)
+                            .font(Font.system(size: 16, weight: .bold))
+                    }
+                    .padding(.leading, 16)
+                }
+        }
     }
 }
-

--- a/InsightCapture/InsightCapture/UIComponents/ImageSourceView.swift
+++ b/InsightCapture/InsightCapture/UIComponents/ImageSourceView.swift
@@ -16,28 +16,33 @@ struct ImageSourceView: View {
         Button {
             isShowingImage = true
         } label: {
-            Image(uiImage: UIImage(data: insight.image!)!)
-                .resizable()
-                .scaledToFit()
-                .cornerRadius(18, corners: .allCorners)
+            if insight.image != nil {
+                Image(uiImage: UIImage(data: insight.image!)!)
+                    .resizable()
+                    .scaledToFit()
+                    .cornerRadius(18, corners: .allCorners)
+            }
         }
         .navigationDestination(isPresented: $isShowingImage) {
-            SwiftUIImageViewer(image: Image(uiImage: UIImage(data: insight.image!)!))
-                .background(Color.black)
-                .navigationBarBackButtonHidden()
-                .toolbarBackground(.hidden, for: .navigationBar)
-                .edgesIgnoringSafeArea(.all)
-//                .preferredColorScheme(.dark)
-                .overlay(alignment: .topLeading) {
-                    Button {
-                        self.isShowingImage = false
-                    } label: {
-                        Label("", systemImage: "arrow.left")
-                            .foregroundColor(.white)
-                            .font(Font.system(size: 16, weight: .bold))
+            if insight.image != nil {
+                
+                SwiftUIImageViewer(image: Image(uiImage: UIImage(data: insight.image!)!))
+                    .background(Color.black)
+                    .navigationBarBackButtonHidden()
+                    .toolbarBackground(.hidden, for: .navigationBar)
+                    .edgesIgnoringSafeArea(.all)
+                //                .preferredColorScheme(.dark)
+                    .overlay(alignment: .topLeading) {
+                        Button {
+                            self.isShowingImage = false
+                        } label: {
+                            Label("", systemImage: "arrow.left")
+                                .foregroundColor(.white)
+                                .font(Font.system(size: 16, weight: .bold))
+                        }
+                        .padding(.leading, 16)
                     }
-                    .padding(.leading, 16)
-                }
+            }
         }
     }
 }

--- a/InsightCapture/InsightCapture/UIComponents/ImageSourceView.swift
+++ b/InsightCapture/InsightCapture/UIComponents/ImageSourceView.swift
@@ -1,0 +1,20 @@
+//
+//  ImageSourceView.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/04/03.
+//
+
+import SwiftUI
+
+struct ImageSourceView: View {
+    @State var insight: InsightData
+    
+    var body: some View {
+        Image(uiImage: UIImage(data: insight.image!)!)
+            .resizable()
+            .scaledToFit()
+            .cornerRadius(18, corners: .allCorners)
+    }
+}
+

--- a/InsightCapture/InsightCapture/UIComponents/OffsetModifier.swift
+++ b/InsightCapture/InsightCapture/UIComponents/OffsetModifier.swift
@@ -1,0 +1,30 @@
+//
+//  OffsetModifier.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/03/29.
+//
+
+import SwiftUI
+
+struct OffsetModifier: ViewModifier {
+    @Binding var offset: CGFloat
+    
+    func body(content: Content) -> some View {
+        content
+            .overlay (
+                GeometryReader { proxy -> Color in
+                    let minY = proxy.frame(in: .named("SCROLL")).minY
+                    
+                    DispatchQueue.main.async {
+                        self.offset = minY
+                    }
+                    
+//                    print(minY)
+                    
+                    return Color.clear
+                }
+                , alignment: .top
+            )
+    }
+}

--- a/InsightCapture/InsightCapture/UIComponents/QuoteSourceView.swift
+++ b/InsightCapture/InsightCapture/UIComponents/QuoteSourceView.swift
@@ -1,0 +1,43 @@
+//
+//  QuoteSourceView.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/04/03.
+//
+
+import SwiftUI
+
+struct QuoteSourceView: View {
+    @State var insight: InsightData
+    
+    var body: some View {
+        ZStack {
+            Rectangle()
+                .foregroundColor(Color.randomColor(from: insight.createdDate ?? Date()))
+                .padding(.horizontal, 50)
+            
+            VStack {
+                Image(systemName: "quote.opening")
+                    .padding(.top, 8)
+                
+                Text(insight.quote ?? "")
+                    .font(Font.system(size: 16, weight: .medium))
+                    .lineLimit(3)
+                    .padding(.top, 8)
+                    .padding(.bottom, 16)
+                
+                Rectangle()
+                    .background(Color.black)
+                    .frame(height: 1)
+                    .padding(.horizontal, 15)
+                
+                HStack {
+                    Spacer()
+                }
+            }
+            .padding(.all, 8)
+            .padding(.vertical, 16)
+            .cornerRadius(10)
+        }
+    }
+}

--- a/InsightCapture/InsightCapture/UIComponents/URLSourceView.swift
+++ b/InsightCapture/InsightCapture/UIComponents/URLSourceView.swift
@@ -1,0 +1,46 @@
+//
+//  URLThumbnailView.swift
+//  InsightCapture
+//
+//  Created by Park Sungmin on 2023/04/03.
+//
+
+import SwiftUI
+
+struct URLSourceView: View {
+    @State var insight: InsightData
+    
+    var body: some View {
+        HStack {
+            if insight.image != nil {
+                Image(uiImage: UIImage(data: insight.image!)!)
+                    .resizable()
+                    .frame(width: 136, height: 76)
+                    .clipped()
+            } else {
+                Rectangle()
+                    .foregroundColor(.clear)
+                    .frame(width: 136, height: 76)
+            }
+            VStack(alignment: .leading) {
+                Text(insight.title ?? "")
+                    .font(Font.system(size: 15, weight: .bold))
+                    .lineLimit(2)
+                    .padding(.vertical, 2)
+                
+                Text(URLComponents(string: insight.urlString ?? "")?.host ?? "")
+                    .font(Font.system(size: 12, weight: .light))
+                    .lineLimit(1)
+                    .foregroundColor(.gray)
+                
+                HStack {
+                    Spacer()
+                }
+            }
+            .padding(.horizontal, 3)
+        }
+        .padding(.all, 8)
+        .background(Color(uiColor: UIColor.systemGray5))
+        .cornerRadius(10)
+    }
+}

--- a/InsightCapture/InsightCapture/UIComponents/URLSourceView.swift
+++ b/InsightCapture/InsightCapture/UIComponents/URLSourceView.swift
@@ -42,5 +42,8 @@ struct URLSourceView: View {
         .padding(.all, 8)
         .background(Color(uiColor: UIColor.systemGray5))
         .cornerRadius(10)
+        .onTapGesture {
+            UIApplication.shared.open(URL(string: insight.urlString ?? "")!)
+        }
     }
 }

--- a/InsightCapture/share/ShareViewController.swift
+++ b/InsightCapture/share/ShareViewController.swift
@@ -3,6 +3,7 @@ import LinkPresentation
 import Social
 import MobileCoreServices
 import UniformTypeIdentifiers
+import SwiftUI
 
 import SnapKit
 
@@ -11,7 +12,6 @@ class ShareViewController: UIViewController {
     // MARK: Properties
     var sourceType: InsightType = .brain
     
-    
     // source - name 으로 작명하였음
     var imageThumbnailImage: UIImage?
     
@@ -19,6 +19,8 @@ class ShareViewController: UIViewController {
     var urlThumbnailImage: UIImage?
     var urlTitle: String?
     var urlDescription: String?
+    
+    var quote: String?
     
     var isShowingSourceViewIndicator: Bool = false {
         willSet {
@@ -60,6 +62,7 @@ class ShareViewController: UIViewController {
     
     lazy var sourceView: UIView = {
         let view = UIView()
+        view.backgroundColor = UIColor(Color.randomColor(from: Date()))
         view.clipsToBounds = true
         return view
     }()
@@ -91,7 +94,14 @@ class ShareViewController: UIViewController {
         return indicatorView
     }()
     
-    
+    lazy var quoteTextView: UILabel = {
+        let label = UILabel()
+        label.text = quote ?? ""
+        label.font = .systemFont(ofSize: 15, weight: .bold)
+        label.numberOfLines = 3
+        label.textAlignment = .center
+        return label
+    }()
     
     lazy var textFieldView: UIView = {
         let view = UIView()
@@ -135,8 +145,18 @@ class ShareViewController: UIViewController {
 
         // 가져온 데이터 중에서
         for items in extensionItems {
+            
+            // 만약 인용 이라면
+            if items.attributedContentText?.string != nil {
+                sourceType = .quote
+                quote = items.attributedContentText?.string ?? ""
+                self.setQuoteSourceLayout()
+                return
+            }
+            
             // NSItemProvider 배열에 담긴 여러 미디어 데이터 중에서
             if let itemProviders = items.attachments {
+                
                 // 미디어 데이터를 하나 확인해서
                 for itemProvider in itemProviders {
                     
@@ -263,6 +283,19 @@ extension ShareViewController {
         }
     }
     
+    func setQuoteSourceLayout() {
+        sourceView.snp.makeConstraints {
+            $0.horizontalEdges.equalToSuperview()
+            $0.top.equalToSuperview()
+            $0.height.equalTo(124)
+        }
+        
+        sourceView.addSubview(quoteTextView)
+        quoteTextView.snp.makeConstraints {
+            $0.edges.equalToSuperview()
+        }
+    }
+    
     func setTextFieldLayout() {
         textFieldView.snp.makeConstraints {
             $0.horizontalEdges.equalToSuperview().inset(16)
@@ -337,7 +370,9 @@ extension ShareViewController {
         case .image:
             insight = .init(image: imageThumbnailImage!, text: descriptionTextField.text ?? "NO_CONTENT", title: titleTextField.text ?? "NO_TITLE")
         case .url:
-            insight = .init(url: url!, text: descriptionTextField.text!, title: titleTextField.text!)
+            insight = .init(url: url!, text: descriptionTextField.text!, title: titleTextField.text!, thumbnailImage: urlThumbnailImage)
+        case .quote:
+            insight = .init(quote: quote ?? "", text: descriptionTextField.text!, title: titleTextField.text!)
         default:
             insight = .init(text: descriptionTextField.text!, title: titleTextField.text!)
         }

--- a/InsightCapture/share/ShareViewController.swift
+++ b/InsightCapture/share/ShareViewController.swift
@@ -146,26 +146,6 @@ class ShareViewController: UIViewController {
         // 가져온 데이터 중에서
         for items in extensionItems {
             
-            // 만약 인용 이라면
-            if items.attributedContentText?.string != nil {
-                sourceType = .quote
-                quote = items.attributedContentText?.string ?? ""
-                
-                if URL(string: quote!) != nil {
-                    sourceType = .url
-                    self.setUrlSourceLayout()
-                    
-                    self.url = URL(string: quote!)
-                    self.fetchData(from: url as! URL)
-                    self.isShowingSourceViewIndicator = false
-                    
-                    return
-                }
-                
-                self.setQuoteSourceLayout()
-                return
-            }
-            
             // NSItemProvider 배열에 담긴 여러 미디어 데이터 중에서
             if let itemProviders = items.attachments {
                 
@@ -199,10 +179,30 @@ class ShareViewController: UIViewController {
                         self.setUrlSourceLayout()
 
                         itemProvider.loadItem(forTypeIdentifier: UTType.url.identifier, options: nil) { (url, error) in
-                            self.url = url as! URL
+                            self.url = url as? URL
                             
                             self.fetchData(from: url as! URL)
                             self.isShowingSourceViewIndicator = false
+                        }
+                    }
+                    
+                    if itemProvider.hasItemConformingToTypeIdentifier(UTType.text.identifier) {
+                        
+                        self.quote = items.attributedContentText?.string ?? "NO"
+
+                        if let url = URL(string: self.quote!) {
+                            sourceType = .url
+                            self.setUrlSourceLayout()
+
+                            self.url = url
+                            
+                            DispatchQueue.main.async {
+                                self.fetchData(from: url)
+                                self.isShowingSourceViewIndicator = false
+                            }
+                        } else {
+                            self.sourceType = .quote
+                            self.setQuoteSourceLayout()
                         }
                     }
                 }

--- a/InsightCapture/share/ShareViewController.swift
+++ b/InsightCapture/share/ShareViewController.swift
@@ -150,6 +150,18 @@ class ShareViewController: UIViewController {
             if items.attributedContentText?.string != nil {
                 sourceType = .quote
                 quote = items.attributedContentText?.string ?? ""
+                
+                if URL(string: quote!) != nil {
+                    sourceType = .url
+                    self.setUrlSourceLayout()
+                    
+                    self.url = URL(string: quote!)
+                    self.fetchData(from: url as! URL)
+                    self.isShowingSourceViewIndicator = false
+                    
+                    return
+                }
+                
                 self.setQuoteSourceLayout()
                 return
             }


### PR DESCRIPTION
# 작업 내용 설명
InsightPageView에 대한 UI 구현 및 일부 개선 적용

# 관련 이슈
- #11 

# 작업의 결과물
|Image|URL|Quote|
|---|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/229997428-9e83db0b-c1b3-4ff6-9f7d-14d1b5c23d68.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/229997661-8cba70b2-f133-46e7-8447-4a3324ab5c9c.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/229997713-e4099cd6-2754-45dc-83ca-b469e9e22262.png">|


|Scrolled|ImageViewer|
|---|---|
|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/229997558-b0d72678-fa77-4c9c-9133-4bf67a234534.png">|<img width="300" alt="image" src="https://user-images.githubusercontent.com/39216546/229997617-4397e741-b755-4b8a-8f52-5048ce27dd15.png">|

## 스크롤뷰 Offset 추적
아래의 코드를 활용하여, 현재 컨텐츠의 Y축 방향 스크롤 값을 추적할 수 있다. 
```swift
struct OffsetModifier: ViewModifier {
    @Binding var offset: CGFloat
    
    func body(content: Content) -> some View {
        content
            .overlay (
                GeometryReader { proxy -> Color in
                    let minY = proxy.frame(in: .named("SCROLL")).minY
                    
                    DispatchQueue.main.async {
                        self.offset = minY
                    }
                    
                    return Color.clear
                }
                , alignment: .top)
    }
}
```

아래처럼 뷰의 `ScrollView`에 modifier로 OffsetModifier를 붙여주면, viewModel.offset에 스크롤뷰의 스크롤 값을 가져와 활용할 수 있다.
```swift
ScrollView { ... }
.modifier(OffsetModifier(offset: $viewModel.offset))
```


## 
Close #11 
